### PR TITLE
Update tonic-build requirement from =0.11.0 to =0.12.1

### DIFF
--- a/arrow-flight/gen/Cargo.toml
+++ b/arrow-flight/gen/Cargo.toml
@@ -34,4 +34,4 @@ publish = false
 # (and checked in) arrow.flight.protocol.rs from changing
 proc-macro2 = { version = "=1.0.86", default-features = false }
 prost-build = { version = "=0.12.6", default-features = false }
-tonic-build = { version = "=0.11.0", default-features = false, features = ["transport", "prost"] }
+tonic-build = { version = "=0.12.1", default-features = false, features = ["transport", "prost"] }


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [apache/arrow-rs#6084](https://togithub.com/apache/arrow-rs/pull/6084).



The original branch is upstream/dependabot/cargo/master/tonic-build-eq-0.12.1