### PR TITLE
fix: check has_min_max_set before invoking min()/max()

### DIFF
--- a/parquet/src/file/metadata/memory.rs
+++ b/parquet/src/file/metadata/memory.rs
@@ -174,11 +174,11 @@ impl<T: ParquetValueType> HeapSize for PageIndex<T> {
 impl<T: ParquetValueType> HeapSize for ValueStatistics<T> {
     fn heap_size(&self) -> usize {
         if self.has_min_max_set() {
-            return self.min().heap_size() + self.max().heap_size()
+            return self.min().heap_size() + self.max().heap_size();
         } else if self.min_is_exact() {
-            return self.min().heap_size()
+            return self.min().heap_size();
         } else if self.max_is_exact() {
-            return self.max().heap_size()
+            return self.max().heap_size();
         }
         0
     }

--- a/parquet/src/file/metadata/memory.rs
+++ b/parquet/src/file/metadata/memory.rs
@@ -173,7 +173,14 @@ impl<T: ParquetValueType> HeapSize for PageIndex<T> {
 
 impl<T: ParquetValueType> HeapSize for ValueStatistics<T> {
     fn heap_size(&self) -> usize {
-        self.min().heap_size() + self.max().heap_size()
+        if self.has_min_max_set() {
+            return self.min().heap_size() + self.max().heap_size()
+        } else if self.min_is_exact() {
+            return self.min().heap_size()
+        } else if self.max_is_exact() {
+            return self.max().heap_size()
+        }
+        0
     }
 }
 impl HeapSize for bool {

--- a/parquet/src/file/metadata/mod.rs
+++ b/parquet/src/file/metadata/mod.rs
@@ -1324,11 +1324,8 @@ mod tests {
             schema_descr.clone(),
             column_orders,
         );
-        let parquet_meta = ParquetMetaData::new(file_metadata.clone(), row_group_meta.clone());
-        let base_expected_size = 1320;
-        assert_eq!(parquet_meta.memory_size(), base_expected_size);
 
-        //Now, add in Exact Statistics
+        // Now, add in Exact Statistics
         let columns_with_stats = schema_descr
             .columns()
             .iter()
@@ -1348,7 +1345,7 @@ mod tests {
         let row_group_meta_with_stats = vec![row_group_meta_with_stats];
 
         let parquet_meta = ParquetMetaData::new(file_metadata.clone(), row_group_meta_with_stats);
-        //no heap allocations for i32 statistics
+        let base_expected_size = 2024;
         assert_eq!(parquet_meta.memory_size(), base_expected_size);
 
         let mut column_index = ColumnIndexBuilder::new();


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [apache/arrow-rs#6092](https://togithub.com/apache/arrow-rs/pull/6092).



The original branch is fork-6092-Fischer0522/fix/min_max_check