### PR TITLE
Optimize `bool_or` using `max_boolean`

### DIFF
--- a/arrow-arith/src/aggregate.rs
+++ b/arrow-arith/src/aggregate.rs
@@ -674,10 +674,7 @@ pub fn bool_and(array: &BooleanArray) -> Option<bool> {
 ///
 /// Returns `None` if the array is empty or only contains null values.
 pub fn bool_or(array: &BooleanArray) -> Option<bool> {
-    if array.null_count() == array.len() {
-        return None;
-    }
-    Some(array.true_count() != 0)
+    max_boolean(array)
 }
 
 /// Returns the sum of values in the primitive array.

--- a/arrow/benches/aggregate_kernels.rs
+++ b/arrow/benches/aggregate_kernels.rs
@@ -82,11 +82,17 @@ fn add_benchmark(c: &mut Criterion) {
             .bench_function("max nonnull mixed", |b| {
                 b.iter(|| max_boolean(&nonnull_bools_mixed))
             })
+            .bench_function("or nonnull mixed", |b| {
+                b.iter(|| bool_or(&nonnull_bools_mixed))
+            })
             .bench_function("min nonnull false", |b| {
                 b.iter(|| min_boolean(&nonnull_bools_all_false))
             })
             .bench_function("max nonnull false", |b| {
                 b.iter(|| max_boolean(&nonnull_bools_all_false))
+            })
+            .bench_function("or nonnull false", |b| {
+                b.iter(|| bool_or(&nonnull_bools_all_false))
             })
             .bench_function("min nonnull true", |b| {
                 b.iter(|| min_boolean(&nonnull_bools_all_true))
@@ -94,11 +100,17 @@ fn add_benchmark(c: &mut Criterion) {
             .bench_function("max nonnull true", |b| {
                 b.iter(|| max_boolean(&nonnull_bools_all_true))
             })
+            .bench_function("or nonnull true", |b| {
+                b.iter(|| bool_or(&nonnull_bools_all_true))
+            })
             .bench_function("min nullable mixed", |b| {
                 b.iter(|| min_boolean(&nullable_bool_mixed))
             })
             .bench_function("max nullable mixed", |b| {
                 b.iter(|| max_boolean(&nullable_bool_mixed))
+            })
+            .bench_function("or nullable mixed", |b| {
+                b.iter(|| bool_or(&nullable_bool_mixed))
             })
             .bench_function("min nullable false", |b| {
                 b.iter(|| min_boolean(&nullable_bool_all_false))
@@ -106,11 +118,17 @@ fn add_benchmark(c: &mut Criterion) {
             .bench_function("max nullable false", |b| {
                 b.iter(|| max_boolean(&nullable_bool_all_false))
             })
+            .bench_function("or nullable false", |b| {
+                b.iter(|| bool_or(&nullable_bool_all_false))
+            })
             .bench_function("min nullable true", |b| {
                 b.iter(|| min_boolean(&nullable_bool_all_true))
             })
             .bench_function("max nullable true", |b| {
                 b.iter(|| max_boolean(&nullable_bool_all_true))
+            })
+            .bench_function("or nullable true", |b| {
+                b.iter(|| bool_or(&nullable_bool_all_true))
             });
     }
 }


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [apache/arrow-rs#6100](https://togithub.com/apache/arrow-rs/pull/6100).



The original branch is fork-6100-simonvandel/optimize-bool-or