### PR TITLE
improvements to `(i)starts_with` and `(i)ends_with`

### DIFF
--- a/arrow-string/src/like.rs
+++ b/arrow-string/src/like.rs
@@ -274,8 +274,8 @@ fn op_binary<'a>(
         Op::Like(neg) => binary_predicate(l, r, neg, Predicate::like),
         Op::ILike(neg) => binary_predicate(l, r, neg, |s| Predicate::ilike(s, false)),
         Op::Contains => Ok(l.zip(r).map(|(l, r)| Some(l?.contains(r?))).collect()),
-        Op::StartsWith => Ok(l.zip(r).map(|(l, r)| Some(l?.starts_with(r?))).collect()),
-        Op::EndsWith => Ok(l.zip(r).map(|(l, r)| Some(l?.ends_with(r?))).collect()),
+        Op::StartsWith => Ok(l.zip(r).map(|(l, r)| Some(crate::predicate::starts_with(l?, r?))).collect()),
+        Op::EndsWith => Ok(l.zip(r).map(|(l, r)| Some(crate::predicate::ends_with(l?, r?))).collect()),
     }
 }
 

--- a/arrow-string/src/like.rs
+++ b/arrow-string/src/like.rs
@@ -273,9 +273,18 @@ fn op_binary<'a>(
     match op {
         Op::Like(neg) => binary_predicate(l, r, neg, Predicate::like),
         Op::ILike(neg) => binary_predicate(l, r, neg, |s| Predicate::ilike(s, false)),
-        Op::Contains => Ok(l.zip(r).map(|(l, r)| Some(l?.contains(r?))).collect()),
-        Op::StartsWith => Ok(l.zip(r).map(|(l, r)| Some(crate::predicate::starts_with(l?, r?))).collect()),
-        Op::EndsWith => Ok(l.zip(r).map(|(l, r)| Some(crate::predicate::ends_with(l?, r?))).collect()),
+        Op::Contains => Ok(l
+            .zip(r)
+            .map(|(l, r)| Some(Predicate::Contains(r?).evaluate(l?)))
+            .collect()),
+        Op::StartsWith => Ok(l
+            .zip(r)
+            .map(|(l, r)| Some(Predicate::StartsWith(r?).evaluate(l?)))
+            .collect()),
+        Op::EndsWith => Ok(l
+            .zip(r)
+            .map(|(l, r)| Some(Predicate::EndsWith(r?).evaluate(l?)))
+            .collect()),
     }
 }
 

--- a/arrow-string/src/predicate.rs
+++ b/arrow-string/src/predicate.rs
@@ -19,6 +19,7 @@ use arrow_array::{ArrayAccessor, BooleanArray};
 use arrow_schema::ArrowError;
 use memchr::memchr2;
 use regex::{Regex, RegexBuilder};
+use std::iter::zip;
 
 /// A string based predicate
 pub enum Predicate<'a> {
@@ -130,19 +131,23 @@ impl<'a> Predicate<'a> {
     }
 }
 
+/// This is faster than `str::starts_with` for small strings.
+/// See <https://github.com/apache/arrow-rs/issues/6107> for more details.
 fn starts_with(haystack: &str, needle: &str, byte_eq_kernel: impl Fn((&u8, &u8)) -> bool) -> bool {
     if needle.len() > haystack.len() {
         false
     } else {
-        std::iter::zip(haystack.as_bytes(), needle.as_bytes()).all(byte_eq_kernel)
+        zip(haystack.as_bytes(), needle.as_bytes()).all(byte_eq_kernel)
     }
 }
 
+/// This is faster than `str::ends_with` for small strings.
+/// See <https://github.com/apache/arrow-rs/issues/6107> for more details.
 fn ends_with(haystack: &str, needle: &str, byte_eq_kernel: impl Fn((&u8, &u8)) -> bool) -> bool {
     if needle.len() > haystack.len() {
         false
     } else {
-        std::iter::zip(
+        zip(
             haystack.as_bytes().iter().rev(),
             needle.as_bytes().iter().rev(),
         )


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [apache/arrow-rs#6118](https://togithub.com/apache/arrow-rs/pull/6118).



The original branch is fork-6118-samuelcolvin/starts_with-ends_with-improvements