### PR TITLE
Support construct BooleanArray from &[u8]

### DIFF
--- a/arrow-array/src/array/boolean_array.rs
+++ b/arrow-array/src/array/boolean_array.rs
@@ -19,7 +19,7 @@ use crate::array::print_long_array;
 use crate::builder::BooleanBuilder;
 use crate::iterator::BooleanIter;
 use crate::{Array, ArrayAccessor, ArrayRef, Scalar};
-use arrow_buffer::{bit_util, BooleanBuffer, MutableBuffer, NullBuffer};
+use arrow_buffer::{bit_util, BooleanBuffer, Buffer, MutableBuffer, NullBuffer};
 use arrow_data::{ArrayData, ArrayDataBuilder};
 use arrow_schema::DataType;
 use std::any::Any;
@@ -49,22 +49,6 @@ use std::sync::Arc;
 /// let values: Vec<_> = arr.iter().collect();
 /// assert_eq!(&values, &[Some(true), None, Some(false), None, Some(false)])
 /// ```
-///
-/// # Example: From `&[u8]`
-///
-/// ```
-/// # use arrow_array::{Array, BooleanArray};
-/// let v: Vec<u8> = vec![1];
-/// let slice = &v[..];
-/// let arr = BooleanArray::from(slice);
-/// assert_eq!(8, arr.len());
-/// assert!(!arr.is_null(0));
-/// assert!(arr.value(0));
-/// ```
-/// convert each bit in `&[u8]` to boolean and use it to build [`BooleanArray`].
-/// using this method will make the following two points self-evident:
-/// * there is no `null` in the constructed [`BooleanArray`];
-/// * the length of the constructed [`BooleanArray`] is always a multiple of 8;
 ///
 /// # Example: Using Builder
 ///
@@ -124,6 +108,24 @@ impl BooleanArray {
             false => BooleanBuffer::new_unset(1),
         };
         Scalar::new(Self::new(values, None))
+    }
+
+    /// Create a new [`BooleanArray`] from a [`Buffer`] specified by `offset` and `len`, the `offset` and `len` in bits
+    /// Logically convert each bit in [`Buffer`] to boolean and use it to build [`BooleanArray`].
+    /// using this method will make the following points self-evident:
+    /// * there is no `null` in the constructed [`BooleanArray`];
+    /// * without considering `buffer.into()`, this method is efficient because there is no need to perform pack and unpack operations on boolean;
+    pub fn new_from_packed(buffer: impl Into<Buffer>, offset: usize, len: usize) -> Self {
+        BooleanBuffer::new(buffer.into(), offset, len).into()
+    }
+
+    /// Create a new [`BooleanArray`] from `&[u8]`
+    /// This method uses `new_from_packed` and constructs a [`Buffer`] using `value`, and offset is set to 0 and len is set to `value.len() * 8`
+    /// using this method will make the following points self-evident:
+    /// * there is no `null` in the constructed [`BooleanArray`];
+    /// * the length of the constructed [`BooleanArray`] is always a multiple of 8;
+    pub fn new_from_u8(value: &[u8]) -> Self {
+        BooleanBuffer::new(Buffer::from(value), 0, value.len() * 8).into()
     }
 
     /// Returns the length of this array.
@@ -365,12 +367,6 @@ impl From<Vec<Option<bool>>> for BooleanArray {
     }
 }
 
-impl From<&[u8]> for BooleanArray {
-    fn from(value: &[u8]) -> Self {
-        Self::from(BooleanBuffer::from(value))
-    }
-}
-
 impl From<ArrayData> for BooleanArray {
     fn from(data: ArrayData) -> Self {
         assert_eq!(
@@ -532,10 +528,29 @@ mod tests {
     }
 
     #[test]
+    fn test_boolean_array_from_packed() {
+        let v = [1_u8, 2_u8, 3_u8];
+        let arr = BooleanArray::new_from_packed(v, 0, 24);
+        assert_eq!(24, arr.len());
+        assert_eq!(0, arr.offset());
+        assert_eq!(0, arr.null_count());
+        assert!(arr.nulls.is_none());
+        for i in 0..24 {
+            assert!(!arr.is_null(i));
+            assert!(arr.is_valid(i));
+            assert_eq!(
+                i == 0 || i == 9 || i == 16 || i == 17,
+                arr.value(i),
+                "failed t {i}"
+            )
+        }
+    }
+
+    #[test]
     fn test_boolean_array_from_slice_u8() {
         let v: Vec<u8> = vec![1, 2, 3];
         let slice = &v[..];
-        let arr = BooleanArray::from(slice);
+        let arr = BooleanArray::new_from_u8(slice);
         assert_eq!(24, arr.len());
         assert_eq!(0, arr.offset());
         assert_eq!(0, arr.null_count());

--- a/arrow-array/src/array/boolean_array.rs
+++ b/arrow-array/src/array/boolean_array.rs
@@ -50,7 +50,7 @@ use std::sync::Arc;
 /// assert_eq!(&values, &[Some(true), None, Some(false), None, Some(false)])
 /// ```
 ///
-/// # Example: From &[u8]
+/// # Example: From `&[u8]`
 ///
 /// ```
 /// # use arrow_array::{Array, BooleanArray};
@@ -63,8 +63,8 @@ use std::sync::Arc;
 /// ```
 /// convert each bit in `&[u8]` to boolean and use it to build [`BooleanArray`].
 /// using this method will make the following two points self-evident:
-/// * There is no `null` in the constructed [`BooleanArray`]
-/// * The length of the constructed [`BooleanArray`] is always a multiple of 8;
+/// * there is no `null` in the constructed [`BooleanArray`];
+/// * the length of the constructed [`BooleanArray`] is always a multiple of 8;
 ///
 /// # Example: Using Builder
 ///

--- a/arrow-buffer/src/buffer/boolean.rs
+++ b/arrow-buffer/src/buffer/boolean.rs
@@ -21,6 +21,7 @@ use crate::{
     bit_util, buffer_bin_and, buffer_bin_or, buffer_bin_xor, buffer_unary_not,
     BooleanBufferBuilder, Buffer, MutableBuffer,
 };
+
 use std::ops::{BitAnd, BitOr, BitXor, Not};
 
 /// A slice-able [`Buffer`] containing bit-packed booleans
@@ -274,6 +275,12 @@ impl From<&[bool]> for BooleanBuffer {
     }
 }
 
+impl From<&[u8]> for BooleanBuffer {
+    fn from(slice: &[u8]) -> Self {
+        BooleanBuffer::new(Buffer::from(slice), 0, slice.len() * 8)
+    }
+}
+
 impl From<Vec<bool>> for BooleanBuffer {
     fn from(value: Vec<bool>) -> Self {
         value.as_slice().into()
@@ -413,5 +420,28 @@ mod tests {
 
         let expected = BooleanBuffer::new(Buffer::from(&[255, 254, 254, 255, 255]), offset, len);
         assert_eq!(!boolean_buf, expected);
+    }
+
+    #[test]
+    fn test_boolean_from_slice_bool() {
+        let v = [true, false, false];
+        let buf = BooleanBuffer::from(&v[..]);
+        assert_eq!(buf.offset(), 0);
+        assert_eq!(buf.len(), 3);
+        assert_eq!(buf.values().len(), 1);
+        assert!(buf.value(0));
+    }
+
+    #[test]
+    fn test_boolean_from_slice_u8() {
+        let v = [1_u8, 2, 3];
+        let buf = BooleanBuffer::from(&v[..]);
+        assert_eq!(buf.offset(), 0);
+        assert_eq!(buf.len(), 24);
+        assert_eq!(buf.values().len(), 3);
+        assert!(buf.value(0));
+        assert!(buf.value(9));
+        assert!(buf.value(16));
+        assert!(buf.value(17));
     }
 }

--- a/arrow-buffer/src/buffer/boolean.rs
+++ b/arrow-buffer/src/buffer/boolean.rs
@@ -275,12 +275,6 @@ impl From<&[bool]> for BooleanBuffer {
     }
 }
 
-impl From<&[u8]> for BooleanBuffer {
-    fn from(slice: &[u8]) -> Self {
-        BooleanBuffer::new(Buffer::from(slice), 0, slice.len() * 8)
-    }
-}
-
 impl From<Vec<bool>> for BooleanBuffer {
     fn from(value: Vec<bool>) -> Self {
         value.as_slice().into()
@@ -430,18 +424,5 @@ mod tests {
         assert_eq!(buf.len(), 3);
         assert_eq!(buf.values().len(), 1);
         assert!(buf.value(0));
-    }
-
-    #[test]
-    fn test_boolean_from_slice_u8() {
-        let v = [1_u8, 2, 3];
-        let buf = BooleanBuffer::from(&v[..]);
-        assert_eq!(buf.offset(), 0);
-        assert_eq!(buf.len(), 24);
-        assert_eq!(buf.values().len(), 3);
-        assert!(buf.value(0));
-        assert!(buf.value(9));
-        assert!(buf.value(16));
-        assert!(buf.value(17));
     }
 }


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [apache/arrow-rs#6127](https://togithub.com/apache/arrow-rs/pull/6127).



The original branch is fork-6127-chloro-pn/support_construct_BooleanArray_from_slice_u8