### PR TITLE
Improve `LIKE` performance for "contains" style queries

### DIFF
--- a/arrow-string/Cargo.toml
+++ b/arrow-string/Cargo.toml
@@ -42,4 +42,4 @@ arrow-select = { workspace = true }
 regex = { version = "1.7.0", default-features = false, features = ["std", "unicode", "perf"] }
 regex-syntax = { version = "0.8.0", default-features = false, features = ["unicode"] }
 num = { version = "0.4", default-features = false, features = ["std"] }
-memchr = "2.7.1"
+memchr = "2.7.4"

--- a/arrow-string/src/like.rs
+++ b/arrow-string/src/like.rs
@@ -273,7 +273,7 @@ fn op_binary<'a>(
     match op {
         Op::Like(neg) => binary_predicate(l, r, neg, Predicate::like),
         Op::ILike(neg) => binary_predicate(l, r, neg, |s| Predicate::ilike(s, false)),
-        Op::Contains => Ok(l.zip(r).map(|(l, r)| Some(str_contains(l?,r?))).collect()),
+        Op::Contains => Ok(l.zip(r).map(|(l, r)| Some(str_contains(l?, r?))).collect()),
         Op::StartsWith => Ok(l.zip(r).map(|(l, r)| Some(l?.starts_with(r?))).collect()),
         Op::EndsWith => Ok(l.zip(r).map(|(l, r)| Some(l?.ends_with(r?))).collect()),
     }

--- a/arrow-string/src/like.rs
+++ b/arrow-string/src/like.rs
@@ -239,7 +239,7 @@ fn op_scalar<'a, T: StringArrayType<'a>>(
     let r = match op {
         Op::Like(neg) => Predicate::like(r)?.evaluate_array(l, neg),
         Op::ILike(neg) => Predicate::ilike(r, l.is_ascii())?.evaluate_array(l, neg),
-        Op::Contains => Predicate::Contains(r).evaluate_array(l, false),
+        Op::Contains => Predicate::contains(r).evaluate_array(l, false),
         Op::StartsWith => Predicate::StartsWith(r).evaluate_array(l, false),
         Op::EndsWith => Predicate::EndsWith(r).evaluate_array(l, false),
     };
@@ -273,10 +273,14 @@ fn op_binary<'a>(
     match op {
         Op::Like(neg) => binary_predicate(l, r, neg, Predicate::like),
         Op::ILike(neg) => binary_predicate(l, r, neg, |s| Predicate::ilike(s, false)),
-        Op::Contains => Ok(l.zip(r).map(|(l, r)| Some(l?.contains(r?))).collect()),
+        Op::Contains => Ok(l.zip(r).map(|(l, r)| Some(str_contains(l?,r?))).collect()),
         Op::StartsWith => Ok(l.zip(r).map(|(l, r)| Some(l?.starts_with(r?))).collect()),
         Op::EndsWith => Ok(l.zip(r).map(|(l, r)| Some(l?.ends_with(r?))).collect()),
     }
+}
+
+fn str_contains(haystack: &str, needle: &str) -> bool {
+    memchr::memmem::find(haystack.as_bytes(), needle.as_bytes()).is_some()
 }
 
 fn binary_predicate<'a>(

--- a/arrow-string/src/predicate.rs
+++ b/arrow-string/src/predicate.rs
@@ -232,4 +232,22 @@ mod tests {
         let r = regex_like(a_eq, false).unwrap();
         assert_eq!(r.to_string(), expected);
     }
+    #[test]
+    fn test_contains() {
+        assert!(Predicate::contains("hay").evaluate("haystack"));
+        assert!(Predicate::contains("haystack").evaluate("haystack"));
+        assert!(Predicate::contains("h").evaluate("haystack"));
+        assert!(Predicate::contains("k").evaluate("haystack"));
+        assert!(Predicate::contains("stack").evaluate("haystack"));
+        assert!(Predicate::contains("sta").evaluate("haystack"));
+        assert!(Predicate::contains("stack").evaluate("hay£stack"));
+        assert!(Predicate::contains("y£s").evaluate("hay£stack"));
+        assert!(Predicate::contains("£").evaluate("hay£stack"));
+        assert!(Predicate::contains("a").evaluate("a"));
+        // not matching
+        assert!(!Predicate::contains("hy").evaluate("haystack"));
+        assert!(!Predicate::contains("stackx").evaluate("haystack"));
+        assert!(!Predicate::contains("x").evaluate("haystack"));
+        assert!(!Predicate::contains("haystack haystack").evaluate("haystack"));
+    }
 }

--- a/arrow-string/src/predicate.rs
+++ b/arrow-string/src/predicate.rs
@@ -111,9 +111,9 @@ impl<'a> Predicate<'a> {
             Predicate::IEqAscii(v) => BooleanArray::from_unary(array, |haystack| {
                 haystack.eq_ignore_ascii_case(v) != negate
             }),
-            Predicate::Contains(finder) => {
-                BooleanArray::from_unary(array, |haystack| finder.find(haystack.as_bytes()).is_some() != negate)
-            }
+            Predicate::Contains(finder) => BooleanArray::from_unary(array, |haystack| {
+                finder.find(haystack.as_bytes()).is_some() != negate
+            }),
             Predicate::StartsWith(v) => {
                 BooleanArray::from_unary(array, |haystack| haystack.starts_with(v) != negate)
             }


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [apache/arrow-rs#6128](https://togithub.com/apache/arrow-rs/pull/6128).



The original branch is fork-6128-samuelcolvin/contains-performance