### PR TITLE
Improve `ILIKE` performance for "contains" style queries where the needle is ASCII

### DIFF
--- a/arrow-string/src/predicate.rs
+++ b/arrow-string/src/predicate.rs
@@ -149,7 +149,9 @@ fn icontains(haystack: &str, needle: &str) -> bool {
     let mut index: usize = 0;
 
     while let Some(hay_byte) = hay_iter.next() {
-        if equals_ignore_ascii_case_kernel((needle_first, hay_byte)) && rest_match(needle_rest, hay_iter.clone()) {
+        if equals_ignore_ascii_case_kernel((needle_first, hay_byte))
+            && rest_match(needle_rest, hay_iter.clone())
+        {
             return true;
         } else {
             if index >= stop_at {
@@ -161,10 +163,7 @@ fn icontains(haystack: &str, needle: &str) -> bool {
     false
 }
 
-fn rest_match<'a>(
-    needle_rest: &[u8],
-    hay_iter: impl Iterator<Item = &'a u8>,
-) -> bool {
+fn rest_match<'a>(needle_rest: &[u8], hay_iter: impl Iterator<Item = &'a u8>) -> bool {
     std::iter::zip(needle_rest, hay_iter).all(equals_ignore_ascii_case_kernel)
 }
 

--- a/arrow-string/src/predicate.rs
+++ b/arrow-string/src/predicate.rs
@@ -29,6 +29,8 @@ pub enum Predicate<'a> {
 
     /// Equality ignoring ASCII case
     IEqAscii(&'a str),
+    /// Contains ignoring ASCII case
+    IContains(&'a str),
     /// Starts with ignoring ASCII case
     IStartsWithAscii(&'a str),
     /// Ends with ignoring ASCII case
@@ -49,11 +51,7 @@ impl<'a> Predicate<'a> {
             Ok(Self::StartsWith(&pattern[..pattern.len() - 1]))
         } else if pattern.starts_with('%') && !contains_like_pattern(&pattern[1..]) {
             Ok(Self::EndsWith(&pattern[1..]))
-        } else if pattern.starts_with('%')
-            && pattern.ends_with('%')
-            && !pattern.ends_with("\\%")
-            && !contains_like_pattern(&pattern[1..pattern.len() - 1])
-        {
+        } else if is_contains_pattern(pattern) {
             Ok(Self::Contains(&pattern[1..pattern.len() - 1]))
         } else {
             Ok(Self::Regex(regex_like(pattern, false)?))
@@ -72,6 +70,8 @@ impl<'a> Predicate<'a> {
                 return Ok(Self::IStartsWithAscii(&pattern[..pattern.len() - 1]));
             } else if pattern.starts_with('%') && !contains_like_pattern(&pattern[1..]) {
                 return Ok(Self::IEndsWithAscii(&pattern[1..]));
+            } else if is_contains_pattern(pattern) {
+                return Ok(Self::IContains(&pattern[1..pattern.len() - 1]));
             }
         }
         Ok(Self::Regex(regex_like(pattern, true)?))
@@ -83,6 +83,7 @@ impl<'a> Predicate<'a> {
             Predicate::Eq(v) => *v == haystack,
             Predicate::IEqAscii(v) => haystack.eq_ignore_ascii_case(v),
             Predicate::Contains(v) => haystack.contains(v),
+            Predicate::IContains(v) => icontains(haystack, v),
             Predicate::StartsWith(v) => haystack.starts_with(v),
             Predicate::IStartsWithAscii(v) => starts_with_ignore_ascii_case(haystack, v),
             Predicate::EndsWith(v) => haystack.ends_with(v),
@@ -109,6 +110,9 @@ impl<'a> Predicate<'a> {
             Predicate::Contains(v) => {
                 BooleanArray::from_unary(array, |haystack| haystack.contains(v) != negate)
             }
+            Predicate::IContains(v) => {
+                BooleanArray::from_unary(array, |haystack| icontains(haystack, v) != negate)
+            }
             Predicate::StartsWith(v) => {
                 BooleanArray::from_unary(array, |haystack| haystack.starts_with(v) != negate)
             }
@@ -128,6 +132,42 @@ impl<'a> Predicate<'a> {
     }
 }
 
+fn icontains(haystack: &str, needle: &str) -> bool {
+    let Some((needle_first, needle_rest)) = needle.as_bytes().split_first() else {
+        // needle is empty, contains always true, matches `str.contains()` behaviour
+        return true;
+    };
+    let mut hay_iter = haystack.as_bytes().iter();
+    if needle_rest.is_empty() {
+        return hay_iter.any(|h| equals_ignore_ascii_case_kernel((needle_first, h)));
+    }
+
+    let Some(stop_at) = haystack.len().checked_sub(needle.len()) else {
+        // needle is longer than haystack
+        return false;
+    };
+    let mut index: usize = 0;
+
+    while let Some(hay_byte) = hay_iter.next() {
+        if equals_ignore_ascii_case_kernel((needle_first, hay_byte)) && rest_match(needle_rest, hay_iter.clone()) {
+            return true;
+        } else {
+            if index >= stop_at {
+                break;
+            }
+            index += 1;
+        }
+    }
+    false
+}
+
+fn rest_match<'a>(
+    needle_rest: &[u8],
+    hay_iter: impl Iterator<Item = &'a u8>,
+) -> bool {
+    std::iter::zip(needle_rest, hay_iter).all(equals_ignore_ascii_case_kernel)
+}
+
 fn starts_with_ignore_ascii_case(haystack: &str, needle: &str) -> bool {
     let end = haystack.len().min(needle.len());
     haystack.is_char_boundary(end) && needle.eq_ignore_ascii_case(&haystack[..end])
@@ -136,6 +176,10 @@ fn starts_with_ignore_ascii_case(haystack: &str, needle: &str) -> bool {
 fn ends_with_ignore_ascii_case(haystack: &str, needle: &str) -> bool {
     let start = haystack.len().saturating_sub(needle.len());
     haystack.is_char_boundary(start) && needle.eq_ignore_ascii_case(&haystack[start..])
+}
+
+fn equals_ignore_ascii_case_kernel((n, h): (&u8, &u8)) -> bool {
+    n.to_ascii_lowercase() == h.to_ascii_lowercase()
 }
 
 /// Transforms a like `pattern` to a regex compatible pattern. To achieve that, it does:
@@ -184,6 +228,13 @@ fn regex_like(pattern: &str, case_insensitive: bool) -> Result<Regex, ArrowError
         })
 }
 
+fn is_contains_pattern(pattern: &str) -> bool {
+    pattern.starts_with('%')
+        && pattern.ends_with('%')
+        && !pattern.ends_with("\\%")
+        && !contains_like_pattern(&pattern[1..pattern.len() - 1])
+}
+
 fn is_like_pattern(c: char) -> bool {
     c == '%' || c == '_'
 }
@@ -201,6 +252,14 @@ mod tests {
         let a_eq = "_%";
         let expected = "^..*$";
         let r = regex_like(a_eq, false).unwrap();
+        assert_eq!(r.to_string(), expected);
+    }
+
+    #[test]
+    fn test_foobar() {
+        let a_eq = "%spanner%";
+        let expected = "^..*$";
+        let r = regex_like(a_eq, true).unwrap();
         assert_eq!(r.to_string(), expected);
     }
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [apache/arrow-rs#6131](https://togithub.com/apache/arrow-rs/pull/6131).



The original branch is fork-6131-samuelcolvin/icontains-performance