### PR TITLE
Update snafu requirement from 0.7 to 0.8 in /object_store

### DIFF
--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -38,7 +38,7 @@ humantime = "2.1"
 itertools = "0.13.0"
 parking_lot = { version = "0.12" }
 percent-encoding = "2.1"
-snafu = "0.7"
+snafu = "0.8"
 tracing = { version = "0.1" }
 url = "2.2"
 walkdir = "2"


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [apache/arrow-rs#6161](https://togithub.com/apache/arrow-rs/pull/6161).



The original branch is upstream/dependabot/cargo/object_store/master/snafu-0.8