### PR TITLE
Make object_store errors non-exhaustive

### DIFF
--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -1225,6 +1225,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// A specialized `Error` for object store-related errors
 #[derive(Debug, Snafu)]
 #[allow(missing_docs)]
+#[non_exhaustive]
 pub enum Error {
     #[snafu(display("Generic {} error: {}", store, source))]
     Generic {

--- a/object_store/src/path/mod.rs
+++ b/object_store/src/path/mod.rs
@@ -37,6 +37,7 @@ pub use parts::{InvalidPart, PathPart};
 /// Error returned by [`Path::parse`]
 #[derive(Debug, Snafu)]
 #[allow(missing_docs)]
+#[non_exhaustive]
 pub enum Error {
     #[snafu(display("Path \"{}\" contained empty path segment", path))]
     EmptySegment { path: String },


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [apache/arrow-rs#6165](https://togithub.com/apache/arrow-rs/pull/6165).



The original branch is fork-6165-tustvold/make-errors-non-exhaustive