### PR TITLE
Implement Prefix Match for `Like/ILike` between Array and Scalar

### DIFF
--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -311,7 +311,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
     }
 
     /// Returns an iterator over the prefix bytes of this array with respect to the prefix length.
-    /// If the prefix length is larger than the string length, it will return the empty string.
+    /// If the prefix length is larger than the string length, it will return the empty slice.
     pub fn prefix_bytes_iter(&self, prefix_len: usize) -> impl Iterator<Item = &[u8]> {
         self.views().into_iter().map(move |v| {
             let len = (*v as u32) as usize;
@@ -335,7 +335,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
     }
 
     /// Returns an iterator over the suffix bytes of this array with respect to the suffix length.
-    /// If the suffix length is larger than the string length, it will return the empty string.
+    /// If the suffix length is larger than the string length, it will return the empty slice.
     pub fn suffix_bytes_iter(&self, suffix_len: usize) -> impl Iterator<Item = &[u8]> {
         self.views().into_iter().map(move |v| {
             let len = (*v as u32) as usize;

--- a/arrow-string/src/like.rs
+++ b/arrow-string/src/like.rs
@@ -989,6 +989,27 @@ mod tests {
         vec![false, true, true, false, false, false, false, true, true, true, true]
     );
 
+    // 😈 is four bytes long.
+    test_utf8_scalar!(
+        test_uff8_array_like_multibyte,
+        vec![
+            "sdlkdfFooßsdfs",
+            "sdlkdfFooSSdggs",
+            "sdlkdfFoosssdsd",
+            "FooS",
+            "Foos",
+            "ﬀooSS",
+            "ﬀooß",
+            "😃sadlksffofsSsh😈klF",
+            "😱slgffoesSsh😈klF",
+            "FFKoSS",
+            "longer than 12 bytes FFKoSS",
+        ],
+        "%Ssh😈klF",
+        like,
+        vec![false, false, false, false, false, false, false, true, true, false, false]
+    );
+
     test_utf8_scalar!(
         test_utf8_array_ilike_scalar_one,
         vec![

--- a/arrow-string/src/predicate.rs
+++ b/arrow-string/src/predicate.rs
@@ -163,7 +163,7 @@ impl<'a> Predicate<'a> {
                     BooleanArray::from(
                         string_view_array
                             .suffix_iter(v.len())
-                            .map(|haystack| ends_with(haystack, v, equals_kernel) != negate)
+                            .map(|haystack| starts_with(haystack, v, equals_kernel) != negate)
                             .collect::<Vec<_>>(),
                     )
                 } else {
@@ -178,7 +178,7 @@ impl<'a> Predicate<'a> {
                         string_view_array
                             .suffix_iter(v.len())
                             .map(|haystack| {
-                                ends_with(haystack, v, equals_ignore_ascii_case_kernel) != negate
+                                starts_with(haystack, v, equals_ignore_ascii_case_kernel) != negate
                             })
                             .collect::<Vec<_>>(),
                     )

--- a/arrow/benches/comparison_kernels.rs
+++ b/arrow/benches/comparison_kernels.rs
@@ -244,6 +244,10 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| bench_like_utf8view_scalar(&string_view_left, "xxxx%"))
     });
 
+    c.bench_function("like_utf8view scalar starts with more than 4 bytes", |b| {
+        b.iter(|| bench_like_utf8view_scalar(&string_view_left, "xxxxxx%"))
+    });
+
     c.bench_function("like_utf8view scalar complex", |b| {
         b.iter(|| bench_like_utf8view_scalar(&string_view_left, "%xx_xx%xxx"))
     });


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [apache/arrow-rs#6231](https://togithub.com/apache/arrow-rs/pull/6231).



The original branch is fork-6231-xinlifoobar/dev/xinli1/optimize_prefix