### PR TITLE
Check the number of rep levels in Parquet read_records

### DIFF
--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -240,6 +240,12 @@ where
                     let (mut records_read, levels_read) =
                         reader.read_rep_levels(out, remaining_records, remaining_levels)?;
 
+                    if levels_read == 0 {
+                        // Tha fact that we're still looping implies there must be some levels to read.
+                        return Err(general_err!(
+                            "Insufficient repetition levels read from column"
+                        ));
+                    }
                     if levels_read == remaining_levels && self.has_record_delimiter {
                         // Reached end of page, which implies records_read < remaining_records
                         // as otherwise would have stopped reading before reaching the end

--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -241,7 +241,7 @@ where
                         reader.read_rep_levels(out, remaining_records, remaining_levels)?;
 
                     if levels_read == 0 {
-                        // Tha fact that we're still looping implies there must be some levels to read.
+                        // The fact that we're still looping implies there must be some levels to read.
                         return Err(general_err!(
                             "Insufficient repetition levels read from column"
                         ));

--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -240,7 +240,7 @@ where
                     let (mut records_read, levels_read) =
                         reader.read_rep_levels(out, remaining_records, remaining_levels)?;
 
-                    if levels_read == 0 {
+                    if records_read == 0 && levels_read == 0 {
                         // The fact that we're still looping implies there must be some levels to read.
                         return Err(general_err!(
                             "Insufficient repetition levels read from column"


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [apache/arrow-rs#6232](https://togithub.com/apache/arrow-rs/pull/6232).



The original branch is fork-6232-jp0317/levels