### PR TITLE
Make the bearer token visible in FlightSqlServiceClient

### DIFF
--- a/arrow-flight/src/sql/client.rs
+++ b/arrow-flight/src/sql/client.rs
@@ -111,8 +111,8 @@ impl FlightSqlServiceClient<Channel> {
     }
 
     /// Share the bearer token with potentially different `DoGet` clients
-    pub fn token(&self) -> &Option<String> {
-        &self.token
+    pub fn token(&self) -> Option<&String> {
+        self.token.as_ref()
     }
 
     /// Set header value.

--- a/arrow-flight/src/sql/client.rs
+++ b/arrow-flight/src/sql/client.rs
@@ -110,6 +110,11 @@ impl FlightSqlServiceClient<Channel> {
         self.token = None;
     }
 
+    /// Share the bearer token with potentially different `DoGet` clients
+    pub fn token(&self) -> &Option<String> {
+        &self.token
+    }
+
     /// Set header value.
     pub fn set_header(&mut self, key: impl Into<String>, value: impl Into<String>) {
         let key: String = key.into();


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [apache/arrow-rs#6254](https://togithub.com/apache/arrow-rs/pull/6254).



The original branch is fork-6254-hstack/expose-flight-sql-token