### PR TITLE
object_store: Migrate from `snafu` to `thiserror`

### DIFF
--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -39,6 +39,7 @@ itertools = "0.13.0"
 parking_lot = { version = "0.12" }
 percent-encoding = "2.1"
 snafu = { version = "0.8", default-features = false, features = ["std", "rust_1_61"] }
+thiserror = "1.0"
 tracing = { version = "0.1" }
 url = "2.2"
 walkdir = "2"

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -38,7 +38,6 @@ humantime = "2.1"
 itertools = "0.13.0"
 parking_lot = { version = "0.12" }
 percent-encoding = "2.1"
-snafu = { version = "0.8", default-features = false, features = ["std", "rust_1_61"] }
 thiserror = "1.0"
 tracing = { version = "0.1" }
 url = "2.2"

--- a/object_store/src/aws/builder.rs
+++ b/object_store/src/aws/builder.rs
@@ -32,7 +32,6 @@ use itertools::Itertools;
 use md5::{Digest, Md5};
 use reqwest::header::{HeaderMap, HeaderValue};
 use serde::{Deserialize, Serialize};
-use snafu::{OptionExt, ResultExt, Snafu};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -43,47 +42,47 @@ use url::Url;
 static DEFAULT_METADATA_ENDPOINT: &str = "http://169.254.169.254";
 
 /// A specialized `Error` for object store-related errors
-#[derive(Debug, Snafu)]
+#[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]
 enum Error {
-    #[snafu(display("Missing bucket name"))]
+    #[error("Missing bucket name")]
     MissingBucketName,
 
-    #[snafu(display("Missing AccessKeyId"))]
+    #[error("Missing AccessKeyId")]
     MissingAccessKeyId,
 
-    #[snafu(display("Missing SecretAccessKey"))]
+    #[error("Missing SecretAccessKey")]
     MissingSecretAccessKey,
 
-    #[snafu(display("Unable parse source url. Url: {}, Error: {}", url, source))]
+    #[error("Unable parse source url. Url: {}, Error: {}", url, source)]
     UnableToParseUrl {
         source: url::ParseError,
         url: String,
     },
 
-    #[snafu(display(
+    #[error(
         "Unknown url scheme cannot be parsed into storage location: {}",
         scheme
-    ))]
+    )]
     UnknownUrlScheme { scheme: String },
 
-    #[snafu(display("URL did not match any known pattern for scheme: {}", url))]
+    #[error("URL did not match any known pattern for scheme: {}", url)]
     UrlNotRecognised { url: String },
 
-    #[snafu(display("Configuration key: '{}' is not known.", key))]
+    #[error("Configuration key: '{}' is not known.", key)]
     UnknownConfigurationKey { key: String },
 
-    #[snafu(display("Invalid Zone suffix for bucket '{bucket}'"))]
+    #[error("Invalid Zone suffix for bucket '{bucket}'")]
     ZoneSuffix { bucket: String },
 
-    #[snafu(display("Invalid encryption type: {}. Valid values are \"AES256\", \"sse:kms\", \"sse:kms:dsse\" and \"sse-c\".", passed))]
+    #[error("Invalid encryption type: {}. Valid values are \"AES256\", \"sse:kms\", \"sse:kms:dsse\" and \"sse-c\".", passed)]
     InvalidEncryptionType { passed: String },
 
-    #[snafu(display(
+    #[error(
         "Invalid encryption header values. Header: {}, source: {}",
         header,
         source
-    ))]
+    )]
     InvalidEncryptionHeader {
         header: &'static str,
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
@@ -589,8 +588,15 @@ impl AmazonS3Builder {
     /// This is a separate member function to allow fallible computation to
     /// be deferred until [`Self::build`] which in turn allows deriving [`Clone`]
     fn parse_url(&mut self, url: &str) -> Result<()> {
-        let parsed = Url::parse(url).context(UnableToParseUrlSnafu { url })?;
-        let host = parsed.host_str().context(UrlNotRecognisedSnafu { url })?;
+        let parsed = Url::parse(url).map_err(|source| {
+            let url = url.into();
+            Error::UnableToParseUrl { url, source }
+        })?;
+
+        let host = parsed
+            .host_str()
+            .ok_or_else(|| Error::UrlNotRecognised { url: url.into() })?;
+
         match parsed.scheme() {
             "s3" | "s3a" => self.bucket_name = Some(host.to_string()),
             "https" => match host.splitn(4, '.').collect_tuple() {
@@ -616,9 +622,12 @@ impl AmazonS3Builder {
                         self.bucket_name = Some(bucket.into());
                     }
                 }
-                _ => return Err(UrlNotRecognisedSnafu { url }.build().into()),
+                _ => return Err(Error::UrlNotRecognised { url: url.into() }.into()),
             },
-            scheme => return Err(UnknownUrlSchemeSnafu { scheme }.build().into()),
+            scheme => {
+                let scheme = scheme.into();
+                return Err(Error::UnknownUrlScheme { scheme }.into());
+            }
         };
         Ok(())
     }
@@ -853,7 +862,7 @@ impl AmazonS3Builder {
             self.parse_url(&url)?;
         }
 
-        let bucket = self.bucket_name.context(MissingBucketNameSnafu)?;
+        let bucket = self.bucket_name.ok_or(Error::MissingBucketName)?;
         let region = self.region.unwrap_or_else(|| "us-east-1".to_string());
         let checksum = self.checksum_algorithm.map(|x| x.get()).transpose()?;
         let copy_if_not_exists = self.copy_if_not_exists.map(|x| x.get()).transpose()?;
@@ -935,7 +944,10 @@ impl AmazonS3Builder {
 
         let (session_provider, zonal_endpoint) = match self.s3_express.get()? {
             true => {
-                let zone = parse_bucket_az(&bucket).context(ZoneSuffixSnafu { bucket: &bucket })?;
+                let zone = parse_bucket_az(&bucket).ok_or_else(|| {
+                    let bucket = bucket.clone();
+                    Error::ZoneSuffix { bucket }
+                })?;
 
                 // https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-Regions-and-Zones.html
                 let endpoint = format!("https://{bucket}.s3express-{zone}.{region}.amazonaws.com");

--- a/object_store/src/aws/credential.rs
+++ b/object_store/src/aws/credential.rs
@@ -29,23 +29,22 @@ use percent_encoding::utf8_percent_encode;
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
 use reqwest::{Client, Method, Request, RequestBuilder, StatusCode};
 use serde::Deserialize;
-use snafu::{ResultExt, Snafu};
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tracing::warn;
 use url::Url;
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, thiserror::Error)]
 #[allow(clippy::enum_variant_names)]
 enum Error {
-    #[snafu(display("Error performing CreateSession request: {source}"))]
+    #[error("Error performing CreateSession request: {source}")]
     CreateSessionRequest { source: crate::client::retry::Error },
 
-    #[snafu(display("Error getting CreateSession response: {source}"))]
+    #[error("Error getting CreateSession response: {source}")]
     CreateSessionResponse { source: reqwest::Error },
 
-    #[snafu(display("Invalid CreateSessionOutput response: {source}"))]
+    #[error("Invalid CreateSessionOutput response: {source}")]
     CreateSessionOutput { source: quick_xml::DeError },
 }
 
@@ -698,13 +697,13 @@ impl TokenProvider for SessionProvider {
             .with_aws_sigv4(Some(authorizer), None)
             .send_retry(retry)
             .await
-            .context(CreateSessionRequestSnafu)?
+            .map_err(|source| Error::CreateSessionRequest { source })?
             .bytes()
             .await
-            .context(CreateSessionResponseSnafu)?;
+            .map_err(|source| Error::CreateSessionResponse { source })?;
 
-        let resp: CreateSessionOutput =
-            quick_xml::de::from_reader(bytes.reader()).context(CreateSessionOutputSnafu)?;
+        let resp: CreateSessionOutput = quick_xml::de::from_reader(bytes.reader())
+            .map_err(|source| Error::CreateSessionOutput { source })?;
 
         let creds = resp.credentials;
         Ok(TemporaryToken {

--- a/object_store/src/aws/resolve.rs
+++ b/object_store/src/aws/resolve.rs
@@ -17,22 +17,21 @@
 
 use crate::aws::STORE;
 use crate::{ClientOptions, Result};
-use snafu::{ensure, OptionExt, ResultExt, Snafu};
 
 /// A specialized `Error` for object store-related errors
-#[derive(Debug, Snafu)]
+#[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]
 enum Error {
-    #[snafu(display("Bucket '{}' not found", bucket))]
+    #[error("Bucket '{}' not found", bucket)]
     BucketNotFound { bucket: String },
 
-    #[snafu(display("Failed to resolve region for bucket '{}'", bucket))]
+    #[error("Failed to resolve region for bucket '{}'", bucket)]
     ResolveRegion {
         bucket: String,
         source: reqwest::Error,
     },
 
-    #[snafu(display("Failed to parse the region for bucket '{}'", bucket))]
+    #[error("Failed to parse the region for bucket '{}'", bucket)]
     RegionParse { bucket: String },
 }
 
@@ -55,22 +54,23 @@ pub async fn resolve_bucket_region(bucket: &str, client_options: &ClientOptions)
 
     let client = client_options.client()?;
 
-    let response = client
-        .head(&endpoint)
-        .send()
-        .await
-        .context(ResolveRegionSnafu { bucket })?;
+    let response = client.head(&endpoint).send().await.map_err(|source| {
+        let bucket = bucket.into();
+        Error::ResolveRegion { bucket, source }
+    })?;
 
-    ensure!(
-        response.status() != StatusCode::NOT_FOUND,
-        BucketNotFoundSnafu { bucket }
-    );
+    if response.status() == StatusCode::NOT_FOUND {
+        let bucket = bucket.into();
+        return Err(Error::BucketNotFound { bucket }.into());
+    }
 
     let region = response
         .headers()
         .get("x-amz-bucket-region")
         .and_then(|x| x.to_str().ok())
-        .context(RegionParseSnafu { bucket })?;
+        .ok_or_else(|| Error::RegionParse {
+            bucket: bucket.into(),
+        })?;
 
     Ok(region.to_string())
 }

--- a/object_store/src/azure/builder.rs
+++ b/object_store/src/azure/builder.rs
@@ -26,7 +26,6 @@ use crate::config::ConfigValue;
 use crate::{ClientConfigKey, ClientOptions, Result, RetryConfig, StaticCredentialProvider};
 use percent_encoding::percent_decode_str;
 use serde::{Deserialize, Serialize};
-use snafu::{OptionExt, ResultExt, Snafu};
 use std::str::FromStr;
 use std::sync::Arc;
 use url::Url;
@@ -45,49 +44,49 @@ const EMULATOR_ACCOUNT_KEY: &str =
 const MSI_ENDPOINT_ENV_KEY: &str = "IDENTITY_ENDPOINT";
 
 /// A specialized `Error` for Azure builder-related errors
-#[derive(Debug, Snafu)]
+#[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]
 enum Error {
-    #[snafu(display("Unable parse source url. Url: {}, Error: {}", url, source))]
+    #[error("Unable parse source url. Url: {}, Error: {}", url, source)]
     UnableToParseUrl {
         source: url::ParseError,
         url: String,
     },
 
-    #[snafu(display(
+    #[error(
         "Unable parse emulator url {}={}, Error: {}",
         env_name,
         env_value,
         source
-    ))]
+    )]
     UnableToParseEmulatorUrl {
         env_name: String,
         env_value: String,
         source: url::ParseError,
     },
 
-    #[snafu(display("Account must be specified"))]
+    #[error("Account must be specified")]
     MissingAccount {},
 
-    #[snafu(display("Container name must be specified"))]
+    #[error("Container name must be specified")]
     MissingContainerName {},
 
-    #[snafu(display(
+    #[error(
         "Unknown url scheme cannot be parsed into storage location: {}",
         scheme
-    ))]
+    )]
     UnknownUrlScheme { scheme: String },
 
-    #[snafu(display("URL did not match any known pattern for scheme: {}", url))]
+    #[error("URL did not match any known pattern for scheme: {}", url)]
     UrlNotRecognised { url: String },
 
-    #[snafu(display("Failed parsing an SAS key"))]
+    #[error("Failed parsing an SAS key")]
     DecodeSasKey { source: std::str::Utf8Error },
 
-    #[snafu(display("Missing component in SAS query pair"))]
+    #[error("Missing component in SAS query pair")]
     MissingSasComponent {},
 
-    #[snafu(display("Configuration key: '{}' is not known.", key))]
+    #[error("Configuration key: '{}' is not known.", key)]
     UnknownConfigurationKey { key: String },
 }
 
@@ -569,11 +568,17 @@ impl MicrosoftAzureBuilder {
     /// This is a separate member function to allow fallible computation to
     /// be deferred until [`Self::build`] which in turn allows deriving [`Clone`]
     fn parse_url(&mut self, url: &str) -> Result<()> {
-        let parsed = Url::parse(url).context(UnableToParseUrlSnafu { url })?;
-        let host = parsed.host_str().context(UrlNotRecognisedSnafu { url })?;
+        let parsed = Url::parse(url).map_err(|source| {
+            let url = url.into();
+            Error::UnableToParseUrl { url, source }
+        })?;
+
+        let host = parsed
+            .host_str()
+            .ok_or_else(|| Error::UrlNotRecognised { url: url.into() })?;
 
         let validate = |s: &str| match s.contains('.') {
-            true => Err(UrlNotRecognisedSnafu { url }.build()),
+            true => Err(Error::UrlNotRecognised { url: url.into() }),
             false => Ok(s.to_string()),
         };
 
@@ -592,7 +597,7 @@ impl MicrosoftAzureBuilder {
                     self.account_name = Some(validate(a)?);
                     self.use_fabric_endpoint = true.into();
                 } else {
-                    return Err(UrlNotRecognisedSnafu { url }.build().into());
+                    return Err(Error::UrlNotRecognised { url: url.into() }.into());
                 }
             }
             "https" => match host.split_once('.') {
@@ -616,9 +621,12 @@ impl MicrosoftAzureBuilder {
                     }
                     self.use_fabric_endpoint = true.into();
                 }
-                _ => return Err(UrlNotRecognisedSnafu { url }.build().into()),
+                _ => return Err(Error::UrlNotRecognised { url: url.into() }.into()),
             },
-            scheme => return Err(UnknownUrlSchemeSnafu { scheme }.build().into()),
+            scheme => {
+                let scheme = scheme.into();
+                return Err(Error::UnknownUrlScheme { scheme }.into());
+            }
         }
         Ok(())
     }
@@ -851,8 +859,10 @@ impl MicrosoftAzureBuilder {
                 },
             };
 
-            let url =
-                Url::parse(&account_url).context(UnableToParseUrlSnafu { url: account_url })?;
+            let url = Url::parse(&account_url).map_err(|source| {
+                let url = account_url.clone();
+                Error::UnableToParseUrl { url, source }
+            })?;
 
             let credential = if let Some(credential) = self.credentials {
                 credential
@@ -933,10 +943,13 @@ impl MicrosoftAzureBuilder {
 /// if present, otherwise falls back to default_url
 fn url_from_env(env_name: &str, default_url: &str) -> Result<Url> {
     let url = match std::env::var(env_name) {
-        Ok(env_value) => Url::parse(&env_value).context(UnableToParseEmulatorUrlSnafu {
-            env_name,
-            env_value,
-        })?,
+        Ok(env_value) => {
+            Url::parse(&env_value).map_err(|source| Error::UnableToParseEmulatorUrl {
+                env_name: env_name.into(),
+                env_value,
+                source,
+            })?
+        }
         Err(_) => Url::parse(default_url).expect("Failed to parse default URL"),
     };
     Ok(url)
@@ -945,7 +958,7 @@ fn url_from_env(env_name: &str, default_url: &str) -> Result<Url> {
 fn split_sas(sas: &str) -> Result<Vec<(String, String)>, Error> {
     let sas = percent_decode_str(sas)
         .decode_utf8()
-        .context(DecodeSasKeySnafu {})?;
+        .map_err(|source| Error::DecodeSasKey { source })?;
     let kv_str_pairs = sas
         .trim_start_matches('?')
         .split('&')

--- a/object_store/src/client/get.rs
+++ b/object_store/src/client/get.rs
@@ -29,7 +29,6 @@ use hyper::header::{
 use hyper::StatusCode;
 use reqwest::header::ToStrError;
 use reqwest::Response;
-use snafu::{ensure, OptionExt, ResultExt, Snafu};
 
 /// A client that can perform a get request
 #[async_trait]
@@ -95,50 +94,52 @@ impl ContentRange {
 }
 
 /// A specialized `Error` for get-related errors
-#[derive(Debug, Snafu)]
+#[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]
 enum GetResultError {
-    #[snafu(context(false))]
+    #[error(transparent)]
     Header {
+        #[from]
         source: crate::client::header::Error,
     },
 
-    #[snafu(transparent)]
+    #[error(transparent)]
     InvalidRangeRequest {
+        #[from]
         source: crate::util::InvalidGetRange,
     },
 
-    #[snafu(display("Received non-partial response when range requested"))]
+    #[error("Received non-partial response when range requested")]
     NotPartial,
 
-    #[snafu(display("Content-Range header not present in partial response"))]
+    #[error("Content-Range header not present in partial response")]
     NoContentRange,
 
-    #[snafu(display("Failed to parse value for CONTENT_RANGE header: \"{value}\""))]
+    #[error("Failed to parse value for CONTENT_RANGE header: \"{value}\"")]
     ParseContentRange { value: String },
 
-    #[snafu(display("Content-Range header contained non UTF-8 characters"))]
+    #[error("Content-Range header contained non UTF-8 characters")]
     InvalidContentRange { source: ToStrError },
 
-    #[snafu(display("Cache-Control header contained non UTF-8 characters"))]
+    #[error("Cache-Control header contained non UTF-8 characters")]
     InvalidCacheControl { source: ToStrError },
 
-    #[snafu(display("Content-Disposition header contained non UTF-8 characters"))]
+    #[error("Content-Disposition header contained non UTF-8 characters")]
     InvalidContentDisposition { source: ToStrError },
 
-    #[snafu(display("Content-Encoding header contained non UTF-8 characters"))]
+    #[error("Content-Encoding header contained non UTF-8 characters")]
     InvalidContentEncoding { source: ToStrError },
 
-    #[snafu(display("Content-Language header contained non UTF-8 characters"))]
+    #[error("Content-Language header contained non UTF-8 characters")]
     InvalidContentLanguage { source: ToStrError },
 
-    #[snafu(display("Content-Type header contained non UTF-8 characters"))]
+    #[error("Content-Type header contained non UTF-8 characters")]
     InvalidContentType { source: ToStrError },
 
-    #[snafu(display("Metadata value for \"{key:?}\" contained non UTF-8 characters"))]
+    #[error("Metadata value for \"{key:?}\" contained non UTF-8 characters")]
     InvalidMetadata { key: String },
 
-    #[snafu(display("Requested {expected:?}, got {actual:?}"))]
+    #[error("Requested {expected:?}, got {actual:?}")]
     UnexpectedRange {
         expected: Range<usize>,
         actual: Range<usize>,
@@ -154,17 +155,24 @@ fn get_result<T: GetClient>(
 
     // ensure that we receive the range we asked for
     let range = if let Some(expected) = range {
-        ensure!(
-            response.status() == StatusCode::PARTIAL_CONTENT,
-            NotPartialSnafu
-        );
+        if response.status() != StatusCode::PARTIAL_CONTENT {
+            return Err(GetResultError::NotPartial);
+        }
+
         let val = response
             .headers()
             .get(CONTENT_RANGE)
-            .context(NoContentRangeSnafu)?;
+            .ok_or(GetResultError::NoContentRange)?;
 
-        let value = val.to_str().context(InvalidContentRangeSnafu)?;
-        let value = ContentRange::from_str(value).context(ParseContentRangeSnafu { value })?;
+        let value = val
+            .to_str()
+            .map_err(|source| GetResultError::InvalidContentRange { source })?;
+
+        let value = ContentRange::from_str(value).ok_or_else(|| {
+            let value = value.into();
+            GetResultError::ParseContentRange { value }
+        })?;
+
         let actual = value.range;
 
         // Update size to reflect full size of object (#5272)
@@ -172,10 +180,9 @@ fn get_result<T: GetClient>(
 
         let expected = expected.as_range(meta.size)?;
 
-        ensure!(
-            actual == expected,
-            UnexpectedRangeSnafu { expected, actual }
-        );
+        if actual != expected {
+            return Err(GetResultError::UnexpectedRange { expected, actual });
+        }
 
         actual
     } else {
@@ -183,11 +190,11 @@ fn get_result<T: GetClient>(
     };
 
     macro_rules! parse_attributes {
-        ($headers:expr, $(($header:expr, $attr:expr, $err:expr)),*) => {{
+        ($headers:expr, $(($header:expr, $attr:expr, $map_err:expr)),*) => {{
             let mut attributes = Attributes::new();
             $(
             if let Some(x) = $headers.get($header) {
-                let x = x.to_str().context($err)?;
+                let x = x.to_str().map_err($map_err)?;
                 attributes.insert($attr, x.to_string().into());
             }
             )*
@@ -197,31 +204,23 @@ fn get_result<T: GetClient>(
 
     let mut attributes = parse_attributes!(
         response.headers(),
-        (
-            CACHE_CONTROL,
-            Attribute::CacheControl,
-            InvalidCacheControlSnafu
-        ),
+        (CACHE_CONTROL, Attribute::CacheControl, |source| {
+            GetResultError::InvalidCacheControl { source }
+        }),
         (
             CONTENT_DISPOSITION,
             Attribute::ContentDisposition,
-            InvalidContentDispositionSnafu
+            |source| GetResultError::InvalidContentDisposition { source }
         ),
-        (
-            CONTENT_ENCODING,
-            Attribute::ContentEncoding,
-            InvalidContentEncodingSnafu
-        ),
-        (
-            CONTENT_LANGUAGE,
-            Attribute::ContentLanguage,
-            InvalidContentLanguageSnafu
-        ),
-        (
-            CONTENT_TYPE,
-            Attribute::ContentType,
-            InvalidContentTypeSnafu
-        )
+        (CONTENT_ENCODING, Attribute::ContentEncoding, |source| {
+            GetResultError::InvalidContentEncoding { source }
+        }),
+        (CONTENT_LANGUAGE, Attribute::ContentLanguage, |source| {
+            GetResultError::InvalidContentLanguage { source }
+        }),
+        (CONTENT_TYPE, Attribute::ContentType, |source| {
+            GetResultError::InvalidContentType { source }
+        })
     );
 
     // Add attributes that match the user-defined metadata prefix (e.g. x-amz-meta-)

--- a/object_store/src/client/header.rs
+++ b/object_store/src/client/header.rs
@@ -22,7 +22,6 @@ use crate::ObjectMeta;
 use chrono::{DateTime, TimeZone, Utc};
 use hyper::header::{CONTENT_LENGTH, ETAG, LAST_MODIFIED};
 use hyper::HeaderMap;
-use snafu::{OptionExt, ResultExt, Snafu};
 
 #[derive(Debug, Copy, Clone)]
 /// Configuration for header extraction
@@ -44,27 +43,27 @@ pub struct HeaderConfig {
     pub user_defined_metadata_prefix: Option<&'static str>,
 }
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[snafu(display("ETag Header missing from response"))]
+    #[error("ETag Header missing from response")]
     MissingEtag,
 
-    #[snafu(display("Received header containing non-ASCII data"))]
+    #[error("Received header containing non-ASCII data")]
     BadHeader { source: reqwest::header::ToStrError },
 
-    #[snafu(display("Last-Modified Header missing from response"))]
+    #[error("Last-Modified Header missing from response")]
     MissingLastModified,
 
-    #[snafu(display("Content-Length Header missing from response"))]
+    #[error("Content-Length Header missing from response")]
     MissingContentLength,
 
-    #[snafu(display("Invalid last modified '{}': {}", last_modified, source))]
+    #[error("Invalid last modified '{}': {}", last_modified, source)]
     InvalidLastModified {
         last_modified: String,
         source: chrono::ParseError,
     },
 
-    #[snafu(display("Invalid content length '{}': {}", content_length, source))]
+    #[error("Invalid content length '{}': {}", content_length, source)]
     InvalidContentLength {
         content_length: String,
         source: std::num::ParseIntError,
@@ -83,7 +82,11 @@ pub fn get_put_result(headers: &HeaderMap, version: &str) -> Result<crate::PutRe
 #[cfg(any(feature = "aws", feature = "gcp", feature = "azure"))]
 pub fn get_version(headers: &HeaderMap, version: &str) -> Result<Option<String>, Error> {
     Ok(match headers.get(version) {
-        Some(x) => Some(x.to_str().context(BadHeaderSnafu)?.to_string()),
+        Some(x) => Some(
+            x.to_str()
+                .map_err(|source| Error::BadHeader { source })?
+                .to_string(),
+        ),
         None => None,
     })
 }
@@ -91,7 +94,10 @@ pub fn get_version(headers: &HeaderMap, version: &str) -> Result<Option<String>,
 /// Extracts an etag from the provided [`HeaderMap`]
 pub fn get_etag(headers: &HeaderMap) -> Result<String, Error> {
     let e_tag = headers.get(ETAG).ok_or(Error::MissingEtag)?;
-    Ok(e_tag.to_str().context(BadHeaderSnafu)?.to_string())
+    Ok(e_tag
+        .to_str()
+        .map_err(|source| Error::BadHeader { source })?
+        .to_string())
 }
 
 /// Extracts [`ObjectMeta`] from the provided [`HeaderMap`]
@@ -102,9 +108,15 @@ pub fn header_meta(
 ) -> Result<ObjectMeta, Error> {
     let last_modified = match headers.get(LAST_MODIFIED) {
         Some(last_modified) => {
-            let last_modified = last_modified.to_str().context(BadHeaderSnafu)?;
+            let last_modified = last_modified
+                .to_str()
+                .map_err(|source| Error::BadHeader { source })?;
+
             DateTime::parse_from_rfc2822(last_modified)
-                .context(InvalidLastModifiedSnafu { last_modified })?
+                .map_err(|source| Error::InvalidLastModified {
+                    last_modified: last_modified.into(),
+                    source,
+                })?
                 .with_timezone(&Utc)
         }
         None if cfg.last_modified_required => return Err(Error::MissingLastModified),
@@ -119,15 +131,25 @@ pub fn header_meta(
 
     let content_length = headers
         .get(CONTENT_LENGTH)
-        .context(MissingContentLengthSnafu)?;
+        .ok_or(Error::MissingContentLength)?;
 
-    let content_length = content_length.to_str().context(BadHeaderSnafu)?;
+    let content_length = content_length
+        .to_str()
+        .map_err(|source| Error::BadHeader { source })?;
+
     let size = content_length
         .parse()
-        .context(InvalidContentLengthSnafu { content_length })?;
+        .map_err(|source| Error::InvalidContentLength {
+            content_length: content_length.into(),
+            source,
+        })?;
 
     let version = match cfg.version_header.and_then(|h| headers.get(h)) {
-        Some(v) => Some(v.to_str().context(BadHeaderSnafu)?.to_string()),
+        Some(v) => Some(
+            v.to_str()
+                .map_err(|source| Error::BadHeader { source })?
+                .to_string(),
+        ),
         None => None,
     };
 

--- a/object_store/src/client/retry.rs
+++ b/object_store/src/client/retry.rs
@@ -22,24 +22,23 @@ use crate::PutPayload;
 use futures::future::BoxFuture;
 use reqwest::header::LOCATION;
 use reqwest::{Client, Request, Response, StatusCode};
-use snafu::Error as SnafuError;
-use snafu::Snafu;
+use std::error::Error as StdError;
 use std::time::{Duration, Instant};
 use tracing::info;
 
 /// Retry request error
-#[derive(Debug, Snafu)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[snafu(display("Received redirect without LOCATION, this normally indicates an incorrectly configured region"))]
+    #[error("Received redirect without LOCATION, this normally indicates an incorrectly configured region")]
     BareRedirect,
 
-    #[snafu(display("Client error with status {status}: {}", body.as_deref().unwrap_or("No Body")))]
+    #[error("Client error with status {status}: {}", body.as_deref().unwrap_or("No Body"))]
     Client {
         status: StatusCode,
         body: Option<String>,
     },
 
-    #[snafu(display("Error after {retries} retries in {elapsed:?}, max_retries:{max_retries}, retry_timeout:{retry_timeout:?}, source:{source}"))]
+    #[error("Error after {retries} retries in {elapsed:?}, max_retries:{max_retries}, retry_timeout:{retry_timeout:?}, source:{source}")]
     Reqwest {
         retries: usize,
         max_retries: usize,

--- a/object_store/src/delimited.rs
+++ b/object_store/src/delimited.rs
@@ -126,7 +126,7 @@ impl LineDelimiter {
     fn finish(&mut self) -> Result<bool> {
         if !self.remainder.is_empty() {
             ensure!(!self.is_quote, UnterminatedStringSnafu);
-            ensure!(!self.is_quote, TrailingEscapeSnafu);
+            ensure!(!self.is_escape, TrailingEscapeSnafu);
 
             self.complete
                 .push_back(Bytes::from(std::mem::take(&mut self.remainder)))

--- a/object_store/src/delimited.rs
+++ b/object_store/src/delimited.rs
@@ -21,16 +21,15 @@ use std::collections::VecDeque;
 
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
-use snafu::{ensure, Snafu};
 
 use super::Result;
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, thiserror::Error)]
 enum Error {
-    #[snafu(display("encountered unterminated string"))]
+    #[error("encountered unterminated string")]
     UnterminatedString,
 
-    #[snafu(display("encountered trailing escape character"))]
+    #[error("encountered trailing escape character")]
     TrailingEscape,
 }
 
@@ -125,8 +124,12 @@ impl LineDelimiter {
     /// Returns `true` if there is no remaining data to be read
     fn finish(&mut self) -> Result<bool> {
         if !self.remainder.is_empty() {
-            ensure!(!self.is_quote, UnterminatedStringSnafu);
-            ensure!(!self.is_escape, TrailingEscapeSnafu);
+            if self.is_quote {
+                return Err(Error::UnterminatedString.into());
+            }
+            if self.is_escape {
+                return Err(Error::TrailingEscape.into());
+            }
 
             self.complete
                 .push_back(Bytes::from(std::mem::take(&mut self.remainder)))

--- a/object_store/src/gcp/builder.rs
+++ b/object_store/src/gcp/builder.rs
@@ -27,40 +27,39 @@ use crate::gcp::{
 };
 use crate::{ClientConfigKey, ClientOptions, Result, RetryConfig, StaticCredentialProvider};
 use serde::{Deserialize, Serialize};
-use snafu::{OptionExt, ResultExt, Snafu};
 use std::str::FromStr;
 use std::sync::Arc;
 use url::Url;
 
 use super::credential::{AuthorizedUserSigningCredentials, InstanceSigningCredentialProvider};
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, thiserror::Error)]
 enum Error {
-    #[snafu(display("Missing bucket name"))]
+    #[error("Missing bucket name")]
     MissingBucketName {},
 
-    #[snafu(display("One of service account path or service account key may be provided."))]
+    #[error("One of service account path or service account key may be provided.")]
     ServiceAccountPathAndKeyProvided,
 
-    #[snafu(display("Unable parse source url. Url: {}, Error: {}", url, source))]
+    #[error("Unable parse source url. Url: {}, Error: {}", url, source)]
     UnableToParseUrl {
         source: url::ParseError,
         url: String,
     },
 
-    #[snafu(display(
+    #[error(
         "Unknown url scheme cannot be parsed into storage location: {}",
         scheme
-    ))]
+    )]
     UnknownUrlScheme { scheme: String },
 
-    #[snafu(display("URL did not match any known pattern for scheme: {}", url))]
+    #[error("URL did not match any known pattern for scheme: {}", url)]
     UrlNotRecognised { url: String },
 
-    #[snafu(display("Configuration key: '{}' is not known.", key))]
+    #[error("Configuration key: '{}' is not known.", key)]
     UnknownConfigurationKey { key: String },
 
-    #[snafu(display("GCP credential error: {}", source))]
+    #[error("GCP credential error: {}", source)]
     Credential { source: credential::Error },
 }
 
@@ -316,12 +315,21 @@ impl GoogleCloudStorageBuilder {
     /// This is a separate member function to allow fallible computation to
     /// be deferred until [`Self::build`] which in turn allows deriving [`Clone`]
     fn parse_url(&mut self, url: &str) -> Result<()> {
-        let parsed = Url::parse(url).context(UnableToParseUrlSnafu { url })?;
-        let host = parsed.host_str().context(UrlNotRecognisedSnafu { url })?;
+        let parsed = Url::parse(url).map_err(|source| Error::UnableToParseUrl {
+            source,
+            url: url.to_string(),
+        })?;
+
+        let host = parsed.host_str().ok_or_else(|| Error::UrlNotRecognised {
+            url: url.to_string(),
+        })?;
 
         match parsed.scheme() {
             "gs" => self.bucket_name = Some(host.to_string()),
-            scheme => return Err(UnknownUrlSchemeSnafu { scheme }.build().into()),
+            scheme => {
+                let scheme = scheme.to_string();
+                return Err(Error::UnknownUrlScheme { scheme }.into());
+            }
         }
         Ok(())
     }
@@ -425,12 +433,14 @@ impl GoogleCloudStorageBuilder {
         // First try to initialize from the service account information.
         let service_account_credentials =
             match (self.service_account_path, self.service_account_key) {
-                (Some(path), None) => {
-                    Some(ServiceAccountCredentials::from_file(path).context(CredentialSnafu)?)
-                }
-                (None, Some(key)) => {
-                    Some(ServiceAccountCredentials::from_key(&key).context(CredentialSnafu)?)
-                }
+                (Some(path), None) => Some(
+                    ServiceAccountCredentials::from_file(path)
+                        .map_err(|source| Error::Credential { source })?,
+                ),
+                (None, Some(key)) => Some(
+                    ServiceAccountCredentials::from_key(&key)
+                        .map_err(|source| Error::Credential { source })?,
+                ),
                 (None, None) => None,
                 (Some(_), Some(_)) => return Err(Error::ServiceAccountPathAndKeyProvided.into()),
             };

--- a/object_store/src/gcp/client.rs
+++ b/object_store/src/gcp/client.rs
@@ -44,7 +44,6 @@ use percent_encoding::{percent_encode, utf8_percent_encode, NON_ALPHANUMERIC};
 use reqwest::header::HeaderName;
 use reqwest::{Client, Method, RequestBuilder, Response, StatusCode};
 use serde::{Deserialize, Serialize};
-use snafu::{OptionExt, ResultExt, Snafu};
 use std::sync::Arc;
 
 const VERSION_HEADER: &str = "x-goog-generation";
@@ -53,59 +52,59 @@ const USER_DEFINED_METADATA_HEADER_PREFIX: &str = "x-goog-meta-";
 
 static VERSION_MATCH: HeaderName = HeaderName::from_static("x-goog-if-generation-match");
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, thiserror::Error)]
 enum Error {
-    #[snafu(display("Error performing list request: {}", source))]
+    #[error("Error performing list request: {}", source)]
     ListRequest { source: crate::client::retry::Error },
 
-    #[snafu(display("Error getting list response body: {}", source))]
+    #[error("Error getting list response body: {}", source)]
     ListResponseBody { source: reqwest::Error },
 
-    #[snafu(display("Got invalid list response: {}", source))]
+    #[error("Got invalid list response: {}", source)]
     InvalidListResponse { source: quick_xml::de::DeError },
 
-    #[snafu(display("Error performing get request {}: {}", path, source))]
+    #[error("Error performing get request {}: {}", path, source)]
     GetRequest {
         source: crate::client::retry::Error,
         path: String,
     },
 
-    #[snafu(display("Error performing request {}: {}", path, source))]
+    #[error("Error performing request {}: {}", path, source)]
     Request {
         source: crate::client::retry::Error,
         path: String,
     },
 
-    #[snafu(display("Error getting put response body: {}", source))]
+    #[error("Error getting put response body: {}", source)]
     PutResponseBody { source: reqwest::Error },
 
-    #[snafu(display("Got invalid put response: {}", source))]
+    #[error("Got invalid put response: {}", source)]
     InvalidPutResponse { source: quick_xml::de::DeError },
 
-    #[snafu(display("Unable to extract metadata from headers: {}", source))]
+    #[error("Unable to extract metadata from headers: {}", source)]
     Metadata {
         source: crate::client::header::Error,
     },
 
-    #[snafu(display("Version required for conditional update"))]
+    #[error("Version required for conditional update")]
     MissingVersion,
 
-    #[snafu(display("Error performing complete multipart request: {}", source))]
+    #[error("Error performing complete multipart request: {}", source)]
     CompleteMultipartRequest { source: crate::client::retry::Error },
 
-    #[snafu(display("Error getting complete multipart response body: {}", source))]
+    #[error("Error getting complete multipart response body: {}", source)]
     CompleteMultipartResponseBody { source: reqwest::Error },
 
-    #[snafu(display("Got invalid multipart response: {}", source))]
+    #[error("Got invalid multipart response: {}", source)]
     InvalidMultipartResponse { source: quick_xml::de::DeError },
 
-    #[snafu(display("Error signing blob: {}", source))]
+    #[error("Error signing blob: {}", source)]
     SignBlobRequest { source: crate::client::retry::Error },
 
-    #[snafu(display("Got invalid signing blob response: {}", source))]
+    #[error("Got invalid signing blob response: {}", source)]
     InvalidSignBlobResponse { source: reqwest::Error },
 
-    #[snafu(display("Got invalid signing blob signature: {}", source))]
+    #[error("Got invalid signing blob signature: {}", source)]
     InvalidSignBlobSignature { source: base64::DecodeError },
 }
 
@@ -233,15 +232,17 @@ impl<'a> Request<'a> {
             .payload(self.payload)
             .send()
             .await
-            .context(RequestSnafu {
-                path: self.path.as_ref(),
+            .map_err(|source| {
+                let path = self.path.as_ref().into();
+                Error::Request { source, path }
             })?;
         Ok(resp)
     }
 
     async fn do_put(self) -> Result<PutResult> {
         let response = self.send().await?;
-        Ok(get_put_result(response.headers(), VERSION_HEADER).context(MetadataSnafu)?)
+        Ok(get_put_result(response.headers(), VERSION_HEADER)
+            .map_err(|source| Error::Metadata { source })?)
     }
 }
 
@@ -329,17 +330,17 @@ impl GoogleCloudStorageClient {
             .idempotent(true)
             .send()
             .await
-            .context(SignBlobRequestSnafu)?;
+            .map_err(|source| Error::SignBlobRequest { source })?;
 
         //If successful, the signature is returned in the signedBlob field in the response.
         let response = response
             .json::<SignBlobResponse>()
             .await
-            .context(InvalidSignBlobResponseSnafu)?;
+            .map_err(|source| Error::InvalidSignBlobResponse { source })?;
 
         let signed_blob = BASE64_STANDARD
             .decode(response.signed_blob)
-            .context(InvalidSignBlobSignatureSnafu)?;
+            .map_err(|source| Error::InvalidSignBlobSignature { source })?;
 
         Ok(hex_encode(&signed_blob))
     }
@@ -382,7 +383,7 @@ impl GoogleCloudStorageClient {
             PutMode::Overwrite => builder.idempotent(true),
             PutMode::Create => builder.header(&VERSION_MATCH, "0"),
             PutMode::Update(v) => {
-                let etag = v.version.as_ref().context(MissingVersionSnafu)?;
+                let etag = v.version.as_ref().ok_or(Error::MissingVersion)?;
                 builder.header(&VERSION_MATCH, etag)
             }
         };
@@ -436,9 +437,14 @@ impl GoogleCloudStorageClient {
             .send()
             .await?;
 
-        let data = response.bytes().await.context(PutResponseBodySnafu)?;
+        let data = response
+            .bytes()
+            .await
+            .map_err(|source| Error::PutResponseBody { source })?;
+
         let result: InitiateMultipartUploadResult =
-            quick_xml::de::from_reader(data.as_ref().reader()).context(InvalidPutResponseSnafu)?;
+            quick_xml::de::from_reader(data.as_ref().reader())
+                .map_err(|source| Error::InvalidPutResponse { source })?;
 
         Ok(result.upload_id)
     }
@@ -456,8 +462,9 @@ impl GoogleCloudStorageClient {
             .query(&[("uploadId", multipart_id)])
             .send_retry(&self.config.retry_config)
             .await
-            .context(RequestSnafu {
-                path: path.as_ref(),
+            .map_err(|source| {
+                let path = path.as_ref().into();
+                Error::Request { source, path }
             })?;
 
         Ok(())
@@ -487,7 +494,7 @@ impl GoogleCloudStorageClient {
         let credential = self.get_credential().await?;
 
         let data = quick_xml::se::to_string(&upload_info)
-            .context(InvalidPutResponseSnafu)?
+            .map_err(|source| Error::InvalidPutResponse { source })?
             // We cannot disable the escaping that transforms "/" to "&quote;" :(
             // https://github.com/tafia/quick-xml/issues/362
             // https://github.com/tafia/quick-xml/issues/350
@@ -503,17 +510,18 @@ impl GoogleCloudStorageClient {
             .idempotent(true)
             .send()
             .await
-            .context(CompleteMultipartRequestSnafu)?;
+            .map_err(|source| Error::CompleteMultipartRequest { source })?;
 
-        let version = get_version(response.headers(), VERSION_HEADER).context(MetadataSnafu)?;
+        let version = get_version(response.headers(), VERSION_HEADER)
+            .map_err(|source| Error::Metadata { source })?;
 
         let data = response
             .bytes()
             .await
-            .context(CompleteMultipartResponseBodySnafu)?;
+            .map_err(|source| Error::CompleteMultipartResponseBody { source })?;
 
-        let response: CompleteMultipartUploadResult =
-            quick_xml::de::from_reader(data.reader()).context(InvalidMultipartResponseSnafu)?;
+        let response: CompleteMultipartUploadResult = quick_xml::de::from_reader(data.reader())
+            .map_err(|source| Error::InvalidMultipartResponse { source })?;
 
         Ok(PutResult {
             e_tag: Some(response.e_tag),
@@ -599,8 +607,9 @@ impl GetClient for GoogleCloudStorageClient {
             .with_get_options(options)
             .send_retry(&self.config.retry_config)
             .await
-            .context(GetRequestSnafu {
-                path: path.as_ref(),
+            .map_err(|source| {
+                let path = path.as_ref().into();
+                Error::GetRequest { source, path }
             })?;
 
         Ok(response)
@@ -649,13 +658,13 @@ impl ListClient for GoogleCloudStorageClient {
             .bearer_auth(&credential.bearer)
             .send_retry(&self.config.retry_config)
             .await
-            .context(ListRequestSnafu)?
+            .map_err(|source| Error::ListRequest { source })?
             .bytes()
             .await
-            .context(ListResponseBodySnafu)?;
+            .map_err(|source| Error::ListResponseBody { source })?;
 
-        let mut response: ListResponse =
-            quick_xml::de::from_reader(response.reader()).context(InvalidListResponseSnafu)?;
+        let mut response: ListResponse = quick_xml::de::from_reader(response.reader())
+            .map_err(|source| Error::InvalidListResponse { source })?;
 
         let token = response.next_continuation_token.take();
         Ok((response.try_into()?, token))

--- a/object_store/src/gcp/credential.rs
+++ b/object_store/src/gcp/credential.rs
@@ -33,7 +33,6 @@ use percent_encoding::utf8_percent_encode;
 use reqwest::{Client, Method};
 use ring::signature::RsaKeyPair;
 use serde::Deserialize;
-use snafu::{ResultExt, Snafu};
 use std::collections::BTreeMap;
 use std::env;
 use std::fs::File;
@@ -54,36 +53,39 @@ const DEFAULT_GCS_SIGN_BLOB_HOST: &str = "storage.googleapis.com";
 const DEFAULT_METADATA_HOST: &str = "metadata.google.internal";
 const DEFAULT_METADATA_IP: &str = "169.254.169.254";
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[snafu(display("Unable to open service account file from {}: {}", path.display(), source))]
+    #[error("Unable to open service account file from {}: {}", path.display(), source)]
     OpenCredentials {
         source: std::io::Error,
         path: PathBuf,
     },
 
-    #[snafu(display("Unable to decode service account file: {}", source))]
+    #[error("Unable to decode service account file: {}", source)]
     DecodeCredentials { source: serde_json::Error },
 
-    #[snafu(display("No RSA key found in pem file"))]
+    #[error("No RSA key found in pem file")]
     MissingKey,
 
-    #[snafu(display("Invalid RSA key: {}", source), context(false))]
-    InvalidKey { source: ring::error::KeyRejected },
+    #[error("Invalid RSA key: {}", source)]
+    InvalidKey {
+        #[from]
+        source: ring::error::KeyRejected,
+    },
 
-    #[snafu(display("Error signing: {}", source))]
+    #[error("Error signing: {}", source)]
     Sign { source: ring::error::Unspecified },
 
-    #[snafu(display("Error encoding jwt payload: {}", source))]
+    #[error("Error encoding jwt payload: {}", source)]
     Encode { source: serde_json::Error },
 
-    #[snafu(display("Unsupported key encoding: {}", encoding))]
+    #[error("Unsupported key encoding: {}", encoding)]
     UnsupportedKey { encoding: String },
 
-    #[snafu(display("Error performing token request: {}", source))]
+    #[error("Error performing token request: {}", source)]
     TokenRequest { source: crate::client::retry::Error },
 
-    #[snafu(display("Error getting token response body: {}", source))]
+    #[error("Error getting token response body: {}", source)]
     TokenResponseBody { source: reqwest::Error },
 }
 
@@ -153,7 +155,7 @@ impl ServiceAccountKey {
                 string_to_sign.as_bytes(),
                 &mut signature,
             )
-            .context(SignSnafu)?;
+            .map_err(|source| Error::Sign { source })?;
 
         Ok(hex_encode(&signature))
     }
@@ -289,7 +291,7 @@ impl TokenProvider for SelfSignedJwt {
                 message.as_bytes(),
                 &mut sig_bytes,
             )
-            .context(SignSnafu)?;
+            .map_err(|source| Error::Sign { source })?;
 
         let signature = BASE64_URL_SAFE_NO_PAD.encode(sig_bytes);
         let bearer = [message, signature].join(".");
@@ -305,11 +307,12 @@ fn read_credentials_file<T>(service_account_path: impl AsRef<std::path::Path>) -
 where
     T: serde::de::DeserializeOwned,
 {
-    let file = File::open(&service_account_path).context(OpenCredentialsSnafu {
-        path: service_account_path.as_ref().to_owned(),
+    let file = File::open(&service_account_path).map_err(|source| {
+        let path = service_account_path.as_ref().to_owned();
+        Error::OpenCredentials { source, path }
     })?;
     let reader = BufReader::new(file);
-    serde_json::from_reader(reader).context(DecodeCredentialsSnafu)
+    serde_json::from_reader(reader).map_err(|source| Error::DecodeCredentials { source })
 }
 
 /// A deserialized `service-account-********.json`-file.
@@ -341,7 +344,7 @@ impl ServiceAccountCredentials {
 
     /// Create a new [`ServiceAccountCredentials`] from a string.
     pub fn from_key(key: &str) -> Result<Self> {
-        serde_json::from_str(key).context(DecodeCredentialsSnafu)
+        serde_json::from_str(key).map_err(|source| Error::DecodeCredentials { source })
     }
 
     /// Create a [`SelfSignedJwt`] from this credentials struct.
@@ -380,7 +383,7 @@ fn seconds_since_epoch() -> u64 {
 }
 
 fn b64_encode_obj<T: serde::Serialize>(obj: &T) -> Result<String> {
-    let string = serde_json::to_string(obj).context(EncodeSnafu)?;
+    let string = serde_json::to_string(obj).map_err(|source| Error::Encode { source })?;
     Ok(BASE64_URL_SAFE_NO_PAD.encode(string))
 }
 
@@ -404,10 +407,10 @@ async fn make_metadata_request(
         .query(&[("audience", "https://www.googleapis.com/oauth2/v4/token")])
         .send_retry(retry)
         .await
-        .context(TokenRequestSnafu)?
+        .map_err(|source| Error::TokenRequest { source })?
         .json()
         .await
-        .context(TokenResponseBodySnafu)?;
+        .map_err(|source| Error::TokenResponseBody { source })?;
     Ok(response)
 }
 
@@ -467,10 +470,10 @@ async fn make_metadata_request_for_email(
         .header("Metadata-Flavor", "Google")
         .send_retry(retry)
         .await
-        .context(TokenRequestSnafu)?
+        .map_err(|source| Error::TokenRequest { source })?
         .text()
         .await
-        .context(TokenResponseBodySnafu)?;
+        .map_err(|source| Error::TokenResponseBody { source })?;
     Ok(response)
 }
 
@@ -608,10 +611,10 @@ impl AuthorizedUserSigningCredentials {
             .query(&[("access_token", &self.credential.refresh_token)])
             .send_retry(retry)
             .await
-            .context(TokenRequestSnafu)?
+            .map_err(|source| Error::TokenRequest { source })?
             .json::<EmailResponse>()
             .await
-            .context(TokenResponseBodySnafu)?;
+            .map_err(|source| Error::TokenResponseBody { source })?;
 
         Ok(response.email)
     }
@@ -659,10 +662,10 @@ impl TokenProvider for AuthorizedUserCredentials {
             .idempotent(true)
             .send()
             .await
-            .context(TokenRequestSnafu)?
+            .map_err(|source| Error::TokenRequest { source })?
             .json::<TokenResponse>()
             .await
-            .context(TokenResponseBodySnafu)?;
+            .map_err(|source| Error::TokenResponseBody { source })?;
 
         Ok(TemporaryToken {
             token: Arc::new(GcpCredential {

--- a/object_store/src/http/client.rs
+++ b/object_store/src/http/client.rs
@@ -32,42 +32,41 @@ use hyper::header::{
 use percent_encoding::percent_decode_str;
 use reqwest::{Method, Response, StatusCode};
 use serde::Deserialize;
-use snafu::{OptionExt, ResultExt, Snafu};
 use url::Url;
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, thiserror::Error)]
 enum Error {
-    #[snafu(display("Request error: {}", source))]
+    #[error("Request error: {}", source)]
     Request { source: retry::Error },
 
-    #[snafu(display("Request error: {}", source))]
+    #[error("Request error: {}", source)]
     Reqwest { source: reqwest::Error },
 
-    #[snafu(display("Range request not supported by {}", href))]
+    #[error("Range request not supported by {}", href)]
     RangeNotSupported { href: String },
 
-    #[snafu(display("Error decoding PROPFIND response: {}", source))]
+    #[error("Error decoding PROPFIND response: {}", source)]
     InvalidPropFind { source: quick_xml::de::DeError },
 
-    #[snafu(display("Missing content size for {}", href))]
+    #[error("Missing content size for {}", href)]
     MissingSize { href: String },
 
-    #[snafu(display("Error getting properties of \"{}\" got \"{}\"", href, status))]
+    #[error("Error getting properties of \"{}\" got \"{}\"", href, status)]
     PropStatus { href: String, status: String },
 
-    #[snafu(display("Failed to parse href \"{}\": {}", href, source))]
+    #[error("Failed to parse href \"{}\": {}", href, source)]
     InvalidHref {
         href: String,
         source: url::ParseError,
     },
 
-    #[snafu(display("Path \"{}\" contained non-unicode characters: {}", path, source))]
+    #[error("Path \"{}\" contained non-unicode characters: {}", path, source)]
     NonUnicode {
         path: String,
         source: std::str::Utf8Error,
     },
 
-    #[snafu(display("Encountered invalid path \"{}\": {}", path, source))]
+    #[error("Encountered invalid path \"{}\": {}", path, source)]
     InvalidPath {
         path: String,
         source: crate::path::Error,
@@ -125,7 +124,7 @@ impl Client {
             .request(method, url)
             .send_retry(&self.retry_config)
             .await
-            .context(RequestSnafu)?;
+            .map_err(|source| Error::Request { source })?;
 
         Ok(())
     }
@@ -232,7 +231,10 @@ impl Client {
             .await;
 
         let response = match result {
-            Ok(result) => result.bytes().await.context(ReqwestSnafu)?,
+            Ok(result) => result
+                .bytes()
+                .await
+                .map_err(|source| Error::Reqwest { source })?,
             Err(e) if matches!(e.status(), Some(StatusCode::NOT_FOUND)) => {
                 return match depth {
                     "0" => {
@@ -251,7 +253,9 @@ impl Client {
             Err(source) => return Err(Error::Request { source }.into()),
         };
 
-        let status = quick_xml::de::from_reader(response.reader()).context(InvalidPropFindSnafu)?;
+        let status = quick_xml::de::from_reader(response.reader())
+            .map_err(|source| Error::InvalidPropFind { source })?;
+
         Ok(status)
     }
 
@@ -393,14 +397,23 @@ impl MultiStatusResponse {
         let url = Url::options()
             .base_url(Some(base_url))
             .parse(&self.href)
-            .context(InvalidHrefSnafu { href: &self.href })?;
+            .map_err(|source| Error::InvalidHref {
+                href: self.href.clone(),
+                source,
+            })?;
 
         // Reverse any percent encoding
         let path = percent_decode_str(url.path())
             .decode_utf8()
-            .context(NonUnicodeSnafu { path: url.path() })?;
+            .map_err(|source| Error::NonUnicode {
+                path: url.path().into(),
+                source,
+            })?;
 
-        Ok(Path::parse(path.as_ref()).context(InvalidPathSnafu { path })?)
+        Ok(Path::parse(path.as_ref()).map_err(|source| {
+            let path = path.into();
+            Error::InvalidPath { path, source }
+        })?)
     }
 
     fn size(&self) -> Result<usize> {
@@ -408,7 +421,10 @@ impl MultiStatusResponse {
             .prop_stat
             .prop
             .content_length
-            .context(MissingSizeSnafu { href: &self.href })?;
+            .ok_or_else(|| Error::MissingSize {
+                href: self.href.clone(),
+            })?;
+
         Ok(size)
     }
 

--- a/object_store/src/http/mod.rs
+++ b/object_store/src/http/mod.rs
@@ -35,7 +35,6 @@ use async_trait::async_trait;
 use futures::stream::BoxStream;
 use futures::{StreamExt, TryStreamExt};
 use itertools::Itertools;
-use snafu::{OptionExt, ResultExt, Snafu};
 use url::Url;
 
 use crate::client::get::GetClientExt;
@@ -49,18 +48,18 @@ use crate::{
 
 mod client;
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, thiserror::Error)]
 enum Error {
-    #[snafu(display("Must specify a URL"))]
+    #[error("Must specify a URL")]
     MissingUrl,
 
-    #[snafu(display("Unable parse source url. Url: {}, Error: {}", url, source))]
+    #[error("Unable parse source url. Url: {}, Error: {}", url, source)]
     UnableToParseUrl {
         source: url::ParseError,
         url: String,
     },
 
-    #[snafu(display("Unable to extract metadata from headers: {}", source))]
+    #[error("Unable to extract metadata from headers: {}", source)]
     Metadata {
         source: crate::client::header::Error,
     },
@@ -235,8 +234,8 @@ impl HttpBuilder {
 
     /// Build an [`HttpStore`] with the configured options
     pub fn build(self) -> Result<HttpStore> {
-        let url = self.url.context(MissingUrlSnafu)?;
-        let parsed = Url::parse(&url).context(UnableToParseUrlSnafu { url })?;
+        let url = self.url.ok_or(Error::MissingUrl)?;
+        let parsed = Url::parse(&url).map_err(|source| Error::UnableToParseUrl { url, source })?;
 
         Ok(HttpStore {
             client: Client::new(parsed, self.client_options, self.retry_config)?,

--- a/object_store/src/local.rs
+++ b/object_store/src/local.rs
@@ -30,7 +30,6 @@ use chrono::{DateTime, Utc};
 use futures::{stream::BoxStream, StreamExt};
 use futures::{FutureExt, TryStreamExt};
 use parking_lot::Mutex;
-use snafu::{ensure, OptionExt, ResultExt, Snafu};
 use url::Url;
 use walkdir::{DirEntry, WalkDir};
 
@@ -43,118 +42,81 @@ use crate::{
 };
 
 /// A specialized `Error` for filesystem object store-related errors
-#[derive(Debug, Snafu)]
+#[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]
 pub(crate) enum Error {
-    #[snafu(display("File size for {} did not fit in a usize: {}", path, source))]
+    #[error("File size for {} did not fit in a usize: {}", path, source)]
     FileSizeOverflowedUsize {
         source: std::num::TryFromIntError,
         path: String,
     },
 
-    #[snafu(display("Unable to walk dir: {}", source))]
-    UnableToWalkDir {
-        source: walkdir::Error,
-    },
+    #[error("Unable to walk dir: {}", source)]
+    UnableToWalkDir { source: walkdir::Error },
 
-    #[snafu(display("Unable to access metadata for {}: {}", path, source))]
+    #[error("Unable to access metadata for {}: {}", path, source)]
     Metadata {
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
         path: String,
     },
 
-    #[snafu(display("Unable to copy data to file: {}", source))]
-    UnableToCopyDataToFile {
-        source: io::Error,
-    },
+    #[error("Unable to copy data to file: {}", source)]
+    UnableToCopyDataToFile { source: io::Error },
 
-    #[snafu(display("Unable to rename file: {}", source))]
-    UnableToRenameFile {
-        source: io::Error,
-    },
+    #[error("Unable to rename file: {}", source)]
+    UnableToRenameFile { source: io::Error },
 
-    #[snafu(display("Unable to create dir {}: {}", path.display(), source))]
-    UnableToCreateDir {
-        source: io::Error,
-        path: PathBuf,
-    },
+    #[error("Unable to create dir {}: {}", path.display(), source)]
+    UnableToCreateDir { source: io::Error, path: PathBuf },
 
-    #[snafu(display("Unable to create file {}: {}", path.display(), source))]
-    UnableToCreateFile {
-        source: io::Error,
-        path: PathBuf,
-    },
+    #[error("Unable to create file {}: {}", path.display(), source)]
+    UnableToCreateFile { source: io::Error, path: PathBuf },
 
-    #[snafu(display("Unable to delete file {}: {}", path.display(), source))]
-    UnableToDeleteFile {
-        source: io::Error,
-        path: PathBuf,
-    },
+    #[error("Unable to delete file {}: {}", path.display(), source)]
+    UnableToDeleteFile { source: io::Error, path: PathBuf },
 
-    #[snafu(display("Unable to open file {}: {}", path.display(), source))]
-    UnableToOpenFile {
-        source: io::Error,
-        path: PathBuf,
-    },
+    #[error("Unable to open file {}: {}", path.display(), source)]
+    UnableToOpenFile { source: io::Error, path: PathBuf },
 
-    #[snafu(display("Unable to read data from file {}: {}", path.display(), source))]
-    UnableToReadBytes {
-        source: io::Error,
-        path: PathBuf,
-    },
+    #[error("Unable to read data from file {}: {}", path.display(), source)]
+    UnableToReadBytes { source: io::Error, path: PathBuf },
 
-    #[snafu(display("Out of range of file {}, expected: {}, actual: {}", path.display(), expected, actual))]
+    #[error("Out of range of file {}, expected: {}, actual: {}", path.display(), expected, actual)]
     OutOfRange {
         path: PathBuf,
         expected: usize,
         actual: usize,
     },
 
-    #[snafu(display("Requested range was invalid"))]
-    InvalidRange {
-        source: InvalidGetRange,
-    },
+    #[error("Requested range was invalid")]
+    InvalidRange { source: InvalidGetRange },
 
-    #[snafu(display("Unable to copy file from {} to {}: {}", from.display(), to.display(), source))]
+    #[error("Unable to copy file from {} to {}: {}", from.display(), to.display(), source)]
     UnableToCopyFile {
         from: PathBuf,
         to: PathBuf,
         source: io::Error,
     },
 
-    NotFound {
-        path: PathBuf,
-        source: io::Error,
-    },
+    #[error("NotFound")]
+    NotFound { path: PathBuf, source: io::Error },
 
-    #[snafu(display("Error seeking file {}: {}", path.display(), source))]
-    Seek {
-        source: io::Error,
-        path: PathBuf,
-    },
+    #[error("Error seeking file {}: {}", path.display(), source)]
+    Seek { source: io::Error, path: PathBuf },
 
-    #[snafu(display("Unable to convert URL \"{}\" to filesystem path", url))]
-    InvalidUrl {
-        url: Url,
-    },
+    #[error("Unable to convert URL \"{}\" to filesystem path", url)]
+    InvalidUrl { url: Url },
 
-    AlreadyExists {
-        path: String,
-        source: io::Error,
-    },
+    #[error("AlreadyExists")]
+    AlreadyExists { path: String, source: io::Error },
 
-    #[snafu(display("Unable to canonicalize filesystem root: {}", path.display()))]
-    UnableToCanonicalize {
-        path: PathBuf,
-        source: io::Error,
-    },
+    #[error("Unable to canonicalize filesystem root: {}", path.display())]
+    UnableToCanonicalize { path: PathBuf, source: io::Error },
 
-    #[snafu(display("Filenames containing trailing '/#\\d+/' are not supported: {}", path))]
-    InvalidPath {
-        path: String,
-    },
+    #[error("Filenames containing trailing '/#\\d+/' are not supported: {}", path)]
+    InvalidPath { path: String },
 
-    #[snafu(display("Upload aborted"))]
+    #[error("Upload aborted")]
     Aborted,
 }
 
@@ -277,8 +239,9 @@ impl LocalFileSystem {
     /// Returns an error if the path does not exist
     ///
     pub fn new_with_prefix(prefix: impl AsRef<std::path::Path>) -> Result<Self> {
-        let path = std::fs::canonicalize(&prefix).context(UnableToCanonicalizeSnafu {
-            path: prefix.as_ref(),
+        let path = std::fs::canonicalize(&prefix).map_err(|source| {
+            let path = prefix.as_ref().into();
+            Error::UnableToCanonicalize { source, path }
         })?;
 
         Ok(Self {
@@ -291,12 +254,12 @@ impl LocalFileSystem {
 
     /// Return an absolute filesystem path of the given file location
     pub fn path_to_filesystem(&self, location: &Path) -> Result<PathBuf> {
-        ensure!(
-            is_valid_file_path(location),
-            InvalidPathSnafu {
-                path: location.as_ref()
-            }
-        );
+        if !is_valid_file_path(location) {
+            let path = location.as_ref().into();
+            let error = Error::InvalidPath { path };
+            return Err(error.into());
+        }
+
         let path = self.config.prefix_to_filesystem(location)?;
 
         #[cfg(target_os = "windows")]
@@ -452,7 +415,9 @@ impl ObjectStore for LocalFileSystem {
             options.check_preconditions(&meta)?;
 
             let range = match options.range {
-                Some(r) => r.as_range(meta.size).context(InvalidRangeSnafu)?,
+                Some(r) => r
+                    .as_range(meta.size)
+                    .map_err(|source| Error::InvalidRange { source })?,
                 None => 0..meta.size,
             };
 
@@ -722,12 +687,15 @@ impl ObjectStore for LocalFileSystem {
 
 /// Creates the parent directories of `path` or returns an error based on `source` if no parent
 fn create_parent_dirs(path: &std::path::Path, source: io::Error) -> Result<()> {
-    let parent = path.parent().ok_or_else(|| Error::UnableToCreateFile {
-        path: path.to_path_buf(),
-        source,
+    let parent = path.parent().ok_or_else(|| {
+        let path = path.to_path_buf();
+        Error::UnableToCreateFile { path, source }
     })?;
 
-    std::fs::create_dir_all(parent).context(UnableToCreateDirSnafu { path: parent })?;
+    std::fs::create_dir_all(parent).map_err(|source| {
+        let path = parent.into();
+        Error::UnableToCreateDir { source, path }
+    })?;
     Ok(())
 }
 
@@ -797,12 +765,14 @@ impl MultipartUpload for LocalUpload {
         let s = Arc::clone(&self.state);
         maybe_spawn_blocking(move || {
             let mut file = s.file.lock();
-            file.seek(SeekFrom::Start(offset))
-                .context(SeekSnafu { path: &s.dest })?;
+            file.seek(SeekFrom::Start(offset)).map_err(|source| {
+                let path = s.dest.clone();
+                Error::Seek { source, path }
+            })?;
 
             data.iter()
                 .try_for_each(|x| file.write_all(x))
-                .context(UnableToCopyDataToFileSnafu)?;
+                .map_err(|source| Error::UnableToCopyDataToFile { source })?;
 
             Ok(())
         })
@@ -810,12 +780,13 @@ impl MultipartUpload for LocalUpload {
     }
 
     async fn complete(&mut self) -> Result<PutResult> {
-        let src = self.src.take().context(AbortedSnafu)?;
+        let src = self.src.take().ok_or(Error::Aborted)?;
         let s = Arc::clone(&self.state);
         maybe_spawn_blocking(move || {
             // Ensure no inflight writes
             let file = s.file.lock();
-            std::fs::rename(&src, &s.dest).context(UnableToRenameFileSnafu)?;
+            std::fs::rename(&src, &s.dest)
+                .map_err(|source| Error::UnableToRenameFile { source })?;
             let metadata = file.metadata().map_err(|e| Error::Metadata {
                 source: e.into(),
                 path: src.to_string_lossy().to_string(),
@@ -830,9 +801,10 @@ impl MultipartUpload for LocalUpload {
     }
 
     async fn abort(&mut self) -> Result<()> {
-        let src = self.src.take().context(AbortedSnafu)?;
+        let src = self.src.take().ok_or(Error::Aborted)?;
         maybe_spawn_blocking(move || {
-            std::fs::remove_file(&src).context(UnableToDeleteFileSnafu { path: &src })?;
+            std::fs::remove_file(&src)
+                .map_err(|source| Error::UnableToDeleteFile { source, path: src })?;
             Ok(())
         })
         .await
@@ -899,22 +871,30 @@ pub(crate) fn chunked_stream(
 pub(crate) fn read_range(file: &mut File, path: &PathBuf, range: Range<usize>) -> Result<Bytes> {
     let to_read = range.end - range.start;
     file.seek(SeekFrom::Start(range.start as u64))
-        .context(SeekSnafu { path })?;
+        .map_err(|source| {
+            let path = path.into();
+            Error::Seek { source, path }
+        })?;
 
     let mut buf = Vec::with_capacity(to_read);
     let read = file
         .take(to_read as u64)
         .read_to_end(&mut buf)
-        .context(UnableToReadBytesSnafu { path })?;
+        .map_err(|source| {
+            let path = path.into();
+            Error::UnableToReadBytes { source, path }
+        })?;
 
-    ensure!(
-        read == to_read,
-        OutOfRangeSnafu {
-            path,
+    if read != to_read {
+        let error = Error::OutOfRange {
+            path: path.into(),
             expected: to_read,
-            actual: read
-        }
-    );
+            actual: read,
+        };
+
+        return Err(error.into());
+    }
+
     Ok(buf.into())
 }
 
@@ -983,8 +963,9 @@ fn get_etag(metadata: &Metadata) -> String {
 
 fn convert_metadata(metadata: Metadata, location: Path) -> Result<ObjectMeta> {
     let last_modified = last_modified(&metadata);
-    let size = usize::try_from(metadata.len()).context(FileSizeOverflowedUsizeSnafu {
-        path: location.as_ref(),
+    let size = usize::try_from(metadata.len()).map_err(|source| {
+        let path = location.as_ref().into();
+        Error::FileSizeOverflowedUsize { source, path }
     })?;
 
     Ok(ObjectMeta {

--- a/object_store/src/memory.rs
+++ b/object_store/src/memory.rs
@@ -25,7 +25,6 @@ use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use futures::{stream::BoxStream, StreamExt};
 use parking_lot::RwLock;
-use snafu::{OptionExt, ResultExt, Snafu};
 
 use crate::multipart::{MultipartStore, PartId};
 use crate::util::InvalidGetRange;
@@ -37,25 +36,25 @@ use crate::{
 use crate::{GetOptions, PutPayload};
 
 /// A specialized `Error` for in-memory object store-related errors
-#[derive(Debug, Snafu)]
+#[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]
 enum Error {
-    #[snafu(display("No data in memory found. Location: {path}"))]
+    #[error("No data in memory found. Location: {path}")]
     NoDataInMemory { path: String },
 
-    #[snafu(display("Invalid range: {source}"))]
+    #[error("Invalid range: {source}")]
     Range { source: InvalidGetRange },
 
-    #[snafu(display("Object already exists at that location: {path}"))]
+    #[error("Object already exists at that location: {path}")]
     AlreadyExists { path: String },
 
-    #[snafu(display("ETag required for conditional update"))]
+    #[error("ETag required for conditional update")]
     MissingETag,
 
-    #[snafu(display("MultipartUpload not found: {id}"))]
+    #[error("MultipartUpload not found: {id}")]
     UploadNotFound { id: String },
 
-    #[snafu(display("Missing part at index: {part}"))]
+    #[error("Missing part at index: {part}")]
     MissingPart { part: usize },
 }
 
@@ -159,7 +158,7 @@ impl Storage {
             }),
             Some(e) => {
                 let existing = e.e_tag.to_string();
-                let expected = v.e_tag.context(MissingETagSnafu)?;
+                let expected = v.e_tag.ok_or(Error::MissingETag)?;
                 if existing == expected {
                     *e = entry;
                     Ok(())
@@ -178,7 +177,7 @@ impl Storage {
             .parse()
             .ok()
             .and_then(|x| self.uploads.get_mut(&x))
-            .context(UploadNotFoundSnafu { id })?;
+            .ok_or_else(|| Error::UploadNotFound { id: id.into() })?;
         Ok(parts)
     }
 
@@ -187,7 +186,7 @@ impl Storage {
             .parse()
             .ok()
             .and_then(|x| self.uploads.remove(&x))
-            .context(UploadNotFoundSnafu { id })?;
+            .ok_or_else(|| Error::UploadNotFound { id: id.into() })?;
         Ok(parts)
     }
 }
@@ -251,7 +250,9 @@ impl ObjectStore for InMemory {
 
         let (range, data) = match options.range {
             Some(range) => {
-                let r = range.as_range(entry.data.len()).context(RangeSnafu)?;
+                let r = range
+                    .as_range(entry.data.len())
+                    .map_err(|source| Error::Range { source })?;
                 (r.clone(), entry.data.slice(r))
             }
             None => (0..entry.data.len(), entry.data),
@@ -273,7 +274,7 @@ impl ObjectStore for InMemory {
             .map(|range| {
                 let r = GetRange::Bounded(range.clone())
                     .as_range(entry.data.len())
-                    .context(RangeSnafu)?;
+                    .map_err(|source| Error::Range { source })?;
 
                 Ok(entry.data.slice(r))
             })
@@ -436,7 +437,7 @@ impl MultipartStore for InMemory {
 
         let mut cap = 0;
         for (part, x) in upload.parts.iter().enumerate() {
-            cap += x.as_ref().context(MissingPartSnafu { part })?.len();
+            cap += x.as_ref().ok_or(Error::MissingPart { part })?.len();
         }
         let mut buf = Vec::with_capacity(cap);
         for x in &upload.parts {
@@ -481,7 +482,7 @@ impl InMemory {
             .map
             .get(location)
             .cloned()
-            .context(NoDataInMemorySnafu {
+            .ok_or_else(|| Error::NoDataInMemory {
                 path: location.to_string(),
             })?;
 

--- a/object_store/src/parse.rs
+++ b/object_store/src/parse.rs
@@ -20,16 +20,18 @@ use crate::local::LocalFileSystem;
 use crate::memory::InMemory;
 use crate::path::Path;
 use crate::ObjectStore;
-use snafu::Snafu;
 use url::Url;
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[snafu(display("Unable to recognise URL \"{}\"", url))]
+    #[error("Unable to recognise URL \"{}\"", url)]
     Unrecognised { url: Url },
 
-    #[snafu(context(false))]
-    Path { source: crate::path::Error },
+    #[error(transparent)]
+    Path {
+        #[from]
+        source: crate::path::Error,
+    },
 }
 
 impl From<Error> for super::Error {

--- a/object_store/src/path/parts.rs
+++ b/object_store/src/path/parts.rs
@@ -19,15 +19,14 @@ use percent_encoding::{percent_encode, AsciiSet, CONTROLS};
 use std::borrow::Cow;
 
 use crate::path::DELIMITER_BYTE;
-use snafu::Snafu;
 
 /// Error returned by [`PathPart::parse`]
-#[derive(Debug, Snafu)]
-#[snafu(display(
+#[derive(Debug, thiserror::Error)]
+#[error(
     "Encountered illegal character sequence \"{}\" whilst parsing path segment \"{}\"",
     illegal,
     segment
-))]
+)]
 #[allow(missing_copy_implementations)]
 pub struct InvalidPart {
     segment: String,

--- a/object_store/src/util.rs
+++ b/object_store/src/util.rs
@@ -24,7 +24,6 @@ use std::{
 use super::Result;
 use bytes::Bytes;
 use futures::{stream::StreamExt, Stream, TryStreamExt};
-use snafu::Snafu;
 
 #[cfg(any(feature = "azure", feature = "http"))]
 pub static RFC1123_FMT: &str = "%a, %d %h %Y %T GMT";
@@ -204,14 +203,12 @@ pub enum GetRange {
     Suffix(usize),
 }
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, thiserror::Error)]
 pub(crate) enum InvalidGetRange {
-    #[snafu(display(
-        "Wanted range starting at {requested}, but object was only {length} bytes long"
-    ))]
+    #[error("Wanted range starting at {requested}, but object was only {length} bytes long")]
     StartTooLarge { requested: usize, length: usize },
 
-    #[snafu(display("Range started at {start} and ended at {end}"))]
+    #[error("Range started at {start} and ended at {end}")]
     Inconsistent { start: usize, end: usize },
 }
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [apache/arrow-rs#6266](https://togithub.com/apache/arrow-rs/pull/6266).



The original branch is fork-6266-Turbo87/object_store/thiserror