### PR TITLE
Do not print compression level in schema printer

### DIFF
--- a/parquet/src/basic.rs
+++ b/parquet/src/basic.rs
@@ -358,6 +358,14 @@ pub enum Compression {
     LZ4_RAW,
 }
 
+impl Compression {
+    /// Returns the codec type of this compression setting as a string, without the compression
+    /// level.
+    pub(crate) fn codec_to_string(self) -> String {
+        format!("{:?}", self).split('(').next().unwrap().to_owned()
+    }
+}
+
 fn split_compression_string(str_setting: &str) -> Result<(&str, Option<u32>), ParquetError> {
     let split_setting = str_setting.split_once('(');
 
@@ -1912,6 +1920,15 @@ mod tests {
         assert_eq!(
             parquet::Encoding::DELTA_BYTE_ARRAY,
             Encoding::DELTA_BYTE_ARRAY.into()
+        );
+    }
+
+    #[test]
+    fn test_compression_codec_to_string() {
+        assert_eq!(Compression::UNCOMPRESSED.codec_to_string(), "UNCOMPRESSED");
+        assert_eq!(
+            Compression::ZSTD(ZstdLevel::default()).codec_to_string(),
+            "ZSTD"
         );
     }
 

--- a/parquet/src/schema/printer.rs
+++ b/parquet/src/schema/printer.rs
@@ -130,7 +130,11 @@ fn print_column_chunk_metadata(out: &mut dyn io::Write, cc_metadata: &ColumnChun
     writeln!(out, "file path: {file_path_str}");
     writeln!(out, "file offset: {}", cc_metadata.file_offset());
     writeln!(out, "num of values: {}", cc_metadata.num_values());
-    writeln!(out, "compression: {}", cc_metadata.compression());
+    writeln!(
+        out,
+        "compression: {}",
+        cc_metadata.compression().codec_to_string()
+    );
     writeln!(
         out,
         "total compressed size (in bytes): {}",


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [apache/arrow-rs#6271](https://togithub.com/apache/arrow-rs/pull/6271).



The original branch is fork-6271-ttencate/fix/do_not_print_compression_level