### PR TITLE
avoid resizing if capacity is enough when (de)compressing

### DIFF
--- a/parquet/src/compression.rs
+++ b/parquet/src/compression.rs
@@ -198,8 +198,10 @@ pub fn create_codec(codec: CodecType, _options: &CodecOptions) -> Result<Option<
 
 /// Resize the `buf` to a new len `n`.
 ///
-/// Replace resizing on the buffer with reserve and set_len for a good performance (no initialization).
-/// And the `set_len` here is safe for the element of the vector is byte whose destruction does nothing.
+/// Replacing `resize` on the `buf` with `reserve` and `set_len` can skip the initialization
+/// cost for a good performance.
+/// And the `set_len` here is safe because the element of the vector is byte whose destruction
+/// does nothing.
 fn resize_without_init(buf: &mut Vec<u8>, n: usize) {
     if n > buf.capacity() {
         buf.reserve(n - buf.len());

--- a/parquet/src/compression.rs
+++ b/parquet/src/compression.rs
@@ -232,7 +232,7 @@ mod snappy_codec {
                 None => decompress_len(input_buf)?,
             };
             let offset = output_buf.len();
-            vec_util::resize_without_init(output_buf, offset + len);
+            vec_util::resize_buffer_without_init(output_buf, offset + len);
 
             self.decoder
                 .decompress(input_buf, &mut output_buf[offset..])
@@ -242,7 +242,7 @@ mod snappy_codec {
         fn compress(&mut self, input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<()> {
             let output_buf_len = output_buf.len();
             let required_len = max_compress_len(input_buf.len());
-            vec_util::resize_without_init(output_buf, output_buf_len + required_len);
+            vec_util::resize_buffer_without_init(output_buf, output_buf_len + required_len);
             let n = self
                 .encoder
                 .compress(input_buf, &mut output_buf[output_buf_len..])?;
@@ -585,7 +585,7 @@ mod lz4_raw_codec {
                     ))
                 }
             };
-            vec_util::resize_without_init(output_buf, offset + required_len);
+            vec_util::resize_buffer_without_init(output_buf, offset + required_len);
             match lz4_flex::block::decompress_into(input_buf, &mut output_buf[offset..]) {
                 Ok(n) => {
                     if n != required_len {
@@ -602,7 +602,7 @@ mod lz4_raw_codec {
         fn compress(&mut self, input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<()> {
             let offset = output_buf.len();
             let required_len = lz4_flex::block::get_maximum_output_size(input_buf.len());
-            vec_util::resize_without_init(output_buf, offset + required_len);
+            vec_util::resize_buffer_without_init(output_buf, offset + required_len);
             match lz4_flex::block::compress_into(input_buf, &mut output_buf[offset..]) {
                 Ok(n) => {
                     output_buf.truncate(offset + n);
@@ -735,7 +735,7 @@ mod lz4_hadoop_codec {
                     ))
                 }
             };
-            vec_util::resize_without_init(output_buf, output_len + required_len);
+            vec_util::resize_buffer_without_init(output_buf, output_len + required_len);
             match try_decompress_hadoop(input_buf, &mut output_buf[output_len..]) {
                 Ok(n) => {
                     if n != required_len {
@@ -766,7 +766,7 @@ mod lz4_hadoop_codec {
         fn compress(&mut self, input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<()> {
             // Allocate memory to store the LZ4_HADOOP prefix.
             let offset = output_buf.len();
-            vec_util::resize_without_init(output_buf, offset + PREFIX_LEN);
+            vec_util::resize_buffer_without_init(output_buf, offset + PREFIX_LEN);
 
             // Append LZ4_RAW compressed bytes after prefix.
             LZ4RawCodec::new().compress(input_buf, output_buf)?;

--- a/parquet/src/util/mod.rs
+++ b/parquet/src/util/mod.rs
@@ -21,6 +21,7 @@ mod bit_pack;
 pub(crate) mod interner;
 #[cfg(any(test, feature = "test_common"))]
 pub(crate) mod test_common;
+pub mod vec_util;
 
 #[cfg(any(test, feature = "test_common"))]
 pub use self::test_common::page_util::{

--- a/parquet/src/util/vec_util.rs
+++ b/parquet/src/util/vec_util.rs
@@ -15,13 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-/// Resize the `buf` to a new len `n`.
+/// Resize the `buf` to a new len `n` without initialization.
 ///
 /// Replacing `resize` on the `buf` with `reserve` and `set_len` can skip the initialization
 /// cost for a good performance.
 /// And the `set_len` here is safe because the element of the vector is byte whose destruction
 /// does nothing.
-pub fn resize_without_init(buf: &mut Vec<u8>, n: usize) {
+// TODO: remove this clippy allow lint if it is used by a module without feature gate.
+#[allow(dead_code)]
+pub fn resize_buffer_without_init(buf: &mut Vec<u8>, n: usize) {
     if n > buf.capacity() {
         buf.reserve(n - buf.len());
     }
@@ -34,7 +36,7 @@ mod tests {
 
     fn resize_and_check(source: Vec<u8>, new_len: usize) {
         let mut new = source.clone();
-        resize_without_init(&mut new, new_len);
+        resize_buffer_without_init(&mut new, new_len);
 
         assert_eq!(new.len(), new_len);
         if new.len() > source.len() {
@@ -45,7 +47,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resize_without_init() {
+    fn test_resize_buffer_without_init() {
         let cases = [
             (vec![1, 2, 3], 10),
             (vec![1, 2, 3], 3),

--- a/parquet/src/util/vec_util.rs
+++ b/parquet/src/util/vec_util.rs
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/// Resize the `buf` to a new len `n`.
+///
+/// Replacing `resize` on the `buf` with `reserve` and `set_len` can skip the initialization
+/// cost for a good performance.
+/// And the `set_len` here is safe because the element of the vector is byte whose destruction
+/// does nothing.
+pub fn resize_without_init(buf: &mut Vec<u8>, n: usize) {
+    if n > buf.capacity() {
+        buf.reserve(n - buf.len());
+    }
+    unsafe { buf.set_len(n) };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn resize_and_check(source: Vec<u8>, new_len: usize) {
+        let mut new = source.clone();
+        resize_without_init(&mut new, new_len);
+
+        assert_eq!(new.len(), new_len);
+        if new.len() > source.len() {
+            assert_eq!(&new[..source.len()], &source[..]);
+        } else {
+            assert_eq!(&new[..], &source[..new.len()]);
+        }
+    }
+
+    #[test]
+    fn test_resize_without_init() {
+        let cases = [
+            (vec![1, 2, 3], 10),
+            (vec![1, 2, 3], 3),
+            (vec![1, 2, 3, 4, 5], 3),
+            (vec![], 10),
+            (vec![], 0),
+        ];
+
+        for (vector, resize_len) in cases {
+            resize_and_check(vector, resize_len);
+        }
+    }
+}


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [apache/arrow-rs#6281](https://togithub.com/apache/arrow-rs/pull/6281).



The original branch is fork-6281-ShiKaiWi/avoid-resize-when-decompress