### PR TITLE
fix reference in doctest to size_of which is not imported by default

### DIFF
--- a/arrow-data/src/transform/mod.rs
+++ b/arrow-data/src/transform/mod.rs
@@ -115,7 +115,7 @@ fn build_extend_null_bits(array: &ArrayData, use_nulls: bool) -> ExtendNullBits 
 /// let arr1  = i32_array(&[1, 2, 3, 4, 5]);
 /// let arr2  = i32_array(&[6, 7, 8, 9, 10]);
 /// // Create a mutable array for copying values from arr1 and arr2, with a capacity for 6 elements
-/// let capacity = 3 * size_of::<i32>();
+/// let capacity = 3 * std::mem::size_of::<i32>();
 /// let mut mutable = MutableArrayData::new(vec![&arr1, &arr2], false, 10);
 /// // Copy the first 3 elements from arr1
 /// mutable.extend(0, 0, 3);


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [apache/arrow-rs#6286](https://togithub.com/apache/arrow-rs/pull/6286).



The original branch is fork-6286-rtyler/doc-test-size-of